### PR TITLE
RT kernel

### DIFF
--- a/features/rt/Makefile
+++ b/features/rt/Makefile
@@ -1,0 +1,8 @@
+.PHONY: all
+all:
+	echo "not implemented yet"
+
+.PHONY: generate
+generate:
+	./hack/generate.sh
+

--- a/features/rt/README.md
+++ b/features/rt/README.md
@@ -1,0 +1,9 @@
+# Realtime
+
+Here you find realtime feature related manifests.
+
+## RT kernel
+
+The realtime kernel will be installed using MachineConfig, which installs a new systemd unit, which runs a script.
+The template for the MC and the script are located in `assets`. The actual manifest is created by running `make rt-kernel-manifest`,
+which will base64 encode the script and put it into the template. The result is stored alongside other manifests in `manifests`.

--- a/features/rt/assets/mc-rtkernel-worker-rt.yaml.in
+++ b/features/rt/assets/mc-rtkernel-worker-rt.yaml.in
@@ -1,0 +1,47 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+    labels:
+        machineconfiguration.openshift.io/role: worker-rt
+    name: 11-rt-kernel-worker-rt
+spec:
+    config:
+        ignition:
+            config: {}
+            security:
+                tls: {}
+            timeouts: {}
+            version: 2.2.0
+        networkd: {}
+        passwd: {}
+        storage:
+            files:
+                - filesystem: root
+                  path: /usr/local/bin/rt-kernel-patch.sh
+                  mode: 0700
+                  contents:
+                      source: data:text/plain;charset=utf-8;base64,_SCRIPT_
+        systemd:
+            units:
+                - contents: |
+                      [Unit]
+                      Description=RT kernel patch
+                      Wants=network-online.target
+                      After=network-online.target
+                      Before=kubelet.service
+
+                      [Service]
+                      Type=exec
+                      RemainAfterExit=true
+
+                      Environment=MICROCODE_URL=http://file.rdu.redhat.com/~walters/microcode_ctl-20190918-3.rhcos.1.el8.x86_64.rpm
+                      Environment=BASEOS_REPO_URL=http://download-node-02.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.1.1/compose/BaseOS/$basearch/os
+                      Environment=APPSTREAM_REPO_URL=http://download-node-02.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.1.1/compose/AppStream/$basearch/os
+                      Environment=RT_REPO_URL=http://download-node-02.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.1.1/compose/RT/$basearch/os
+
+                      ExecStart=/usr/local/bin/rt-kernel-patch.sh
+
+                      [Install]
+                      WantedBy=multi-user.target
+                  enabled: true
+                  name: rt-kernel.service

--- a/features/rt/assets/rt-kernel-patch.sh
+++ b/features/rt/assets/rt-kernel-patch.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ ! -f /etc/yum.repos.d/rhel.repo ]]
+then
+    # Enable yum repo
+    mkdir -p /etc/yum.repos.d
+    cat > /etc/yum.repos.d/rhel.repo <<EOF
+[baseos]
+baseurl=${BASEOS_REPO_URL}
+gpgcheck=0
+
+[appstream]
+baseurl=${APPSTREAM_REPO_URL}
+gpgcheck=0
+
+[rt]
+baseurl=${RT_REPO_URL}
+gpgcheck=0
+EOF
+fi
+
+# Install patched microcode
+# see https://src.osci.redhat.com/rpms/microcode_ctl/pull-request/9
+replacedPackages=$(rpm-ostree status --json | jq '.deployments[] | select(.booted == true) | ."layered-commit-meta"."rpmostree.replaced-base-packages"')
+if [[ $replacedPackages =~ "microcode_ctl" ]]
+then
+    echo "microcode_ctl patch already installed"
+else
+    rpm-ostree override replace ${MICROCODE_URL}
+fi
+
+# Swap to RT kernel
+kernel=$(uname -a)
+if [[ $kernel =~ "PREEMPT RT" ]]
+then
+    # TODO: check for RT kernel updates
+    echo "RT kernel already installed"
+else
+    rpm-ostree override remove kernel{,-core,-modules,-modules-extra} --install kernel-rt --install kernel-rt-core --install kernel-rt-modules --install kernel-rt-modules-extra
+    systemctl reboot
+fi

--- a/features/rt/hack/generate.sh
+++ b/features/rt/hack/generate.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+assetsDir=$(dirname "$0")/../assets
+manifestsDir=$(dirname "$0")/../manifests
+
+# Generate RT kernel MC
+echo "generating 06-mc-rtkernel-worker-rt.yaml"
+SCRIPT64="$(base64 -w 0 ${assetsDir}/rt-kernel-patch.sh)"
+sed "s/_SCRIPT_/$SCRIPT64/" ${assetsDir}/mc-rtkernel-worker-rt.yaml.in > ${manifestsDir}/06-mc-rtkernel-worker-rt.yaml

--- a/features/rt/manifests/06-mc-rtkernel-worker-rt.yaml
+++ b/features/rt/manifests/06-mc-rtkernel-worker-rt.yaml
@@ -1,0 +1,47 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+    labels:
+        machineconfiguration.openshift.io/role: worker-rt
+    name: 11-rt-kernel-worker-rt
+spec:
+    config:
+        ignition:
+            config: {}
+            security:
+                tls: {}
+            timeouts: {}
+            version: 2.2.0
+        networkd: {}
+        passwd: {}
+        storage:
+            files:
+                - filesystem: root
+                  path: /usr/local/bin/rt-kernel-patch.sh
+                  mode: 0700
+                  contents:
+                      source: data:text/plain;charset=utf-8;base64,IyEvYmluL2Jhc2gKCnNldCAtZXVvIHBpcGVmYWlsCgppZiBbWyAhIC1mIC9ldGMveXVtLnJlcG9zLmQvcmhlbC5yZXBvIF1dCnRoZW4KICAgICMgRW5hYmxlIHl1bSByZXBvCiAgICBta2RpciAtcCAvZXRjL3l1bS5yZXBvcy5kCiAgICBjYXQgPiAvZXRjL3l1bS5yZXBvcy5kL3JoZWwucmVwbyA8PEVPRgpbYmFzZW9zXQpiYXNldXJsPSR7QkFTRU9TX1JFUE9fVVJMfQpncGdjaGVjaz0wCgpbYXBwc3RyZWFtXQpiYXNldXJsPSR7QVBQU1RSRUFNX1JFUE9fVVJMfQpncGdjaGVjaz0wCgpbcnRdCmJhc2V1cmw9JHtSVF9SRVBPX1VSTH0KZ3BnY2hlY2s9MApFT0YKZmkKCiMgSW5zdGFsbCBwYXRjaGVkIG1pY3JvY29kZQojIHNlZSBodHRwczovL3NyYy5vc2NpLnJlZGhhdC5jb20vcnBtcy9taWNyb2NvZGVfY3RsL3B1bGwtcmVxdWVzdC85CnJlcGxhY2VkUGFja2FnZXM9JChycG0tb3N0cmVlIHN0YXR1cyAtLWpzb24gfCBqcSAnLmRlcGxveW1lbnRzW10gfCBzZWxlY3QoLmJvb3RlZCA9PSB0cnVlKSB8IC4ibGF5ZXJlZC1jb21taXQtbWV0YSIuInJwbW9zdHJlZS5yZXBsYWNlZC1iYXNlLXBhY2thZ2VzIicpCmlmIFtbICRyZXBsYWNlZFBhY2thZ2VzID1+ICJtaWNyb2NvZGVfY3RsIiBdXQp0aGVuCiAgICBlY2hvICJtaWNyb2NvZGVfY3RsIHBhdGNoIGFscmVhZHkgaW5zdGFsbGVkIgplbHNlCiAgICBycG0tb3N0cmVlIG92ZXJyaWRlIHJlcGxhY2UgJHtNSUNST0NPREVfVVJMfQpmaQoKIyBTd2FwIHRvIFJUIGtlcm5lbAprZXJuZWw9JCh1bmFtZSAtYSkKaWYgW1sgJGtlcm5lbCA9fiAiUFJFRU1QVCBSVCIgXV0KdGhlbgogICAgIyBUT0RPOiBjaGVjayBmb3IgUlQga2VybmVsIHVwZGF0ZXMKICAgIGVjaG8gIlJUIGtlcm5lbCBhbHJlYWR5IGluc3RhbGxlZCIKZWxzZQogICAgcnBtLW9zdHJlZSBvdmVycmlkZSByZW1vdmUga2VybmVseywtY29yZSwtbW9kdWxlcywtbW9kdWxlcy1leHRyYX0gLS1pbnN0YWxsIGtlcm5lbC1ydCAtLWluc3RhbGwga2VybmVsLXJ0LWNvcmUgLS1pbnN0YWxsIGtlcm5lbC1ydC1tb2R1bGVzIC0taW5zdGFsbCBrZXJuZWwtcnQtbW9kdWxlcy1leHRyYQogICAgc3lzdGVtY3RsIHJlYm9vdApmaQo=
+        systemd:
+            units:
+                - contents: |
+                      [Unit]
+                      Description=RT kernel patch
+                      Wants=network-online.target
+                      After=network-online.target
+                      Before=kubelet.service
+
+                      [Service]
+                      Type=exec
+                      RemainAfterExit=true
+
+                      Environment=MICROCODE_URL=http://file.rdu.redhat.com/~walters/microcode_ctl-20190918-3.rhcos.1.el8.x86_64.rpm
+                      Environment=BASEOS_REPO_URL=http://download-node-02.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.1.1/compose/BaseOS/$basearch/os
+                      Environment=APPSTREAM_REPO_URL=http://download-node-02.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.1.1/compose/AppStream/$basearch/os
+                      Environment=RT_REPO_URL=http://download-node-02.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.1.1/compose/RT/$basearch/os
+
+                      ExecStart=/usr/local/bin/rt-kernel-patch.sh
+
+                      [Install]
+                      WantedBy=multi-user.target
+                  enabled: true
+                  name: rt-kernel.service


### PR DESCRIPTION
~This is based on https://github.com/openshift-kni/baremetal-deploy/pull/20!~
edit: #20 moved to `performance` dir, I leave this in `rt`for now. We can merge later if needed

This adds the realtime kernel feature with
- a MachineConfig template
- a install script
- a generate script, which base64 encodes the install script and puts it into the MC template
- a Makefile, because it's easier to use than searching/calling the generate script (and whatever might follow)
- a initial README.md
- and the generated manifest