### PR TITLE
Support rt kernel updates

### DIFF
--- a/features/performance/README.md
+++ b/features/performance/README.md
@@ -8,6 +8,14 @@ This is a list of environment variables that you should export before running `m
 
 - `ISOLATED_CPUS` - CPU's that you want to isolate from the system usage.
 - `RESERVED_CPUS` - CPU's that you want to reserve for the system and does not use for containers workloads.
+- `MICROCODE_URL` - the location of the patched microcode_ctl RPM, as long as it is not part of RHCOS yet.  
+  Defaults to a RH internal URL. For deployments outside the RH network provide the RPM on a reachable host and
+  update this URL.  
+  See https://bugzilla.redhat.com/show_bug.cgi?id=1766178 for more info on this.
+- `RT_REPO_URL` - the location of a yum repo which provides the RT kernel RPMs as long as they are not part of RHCOS yet.  
+  Defaults to a RH internal URL. For deployments outside the RH network provide a yum repo on a reachable host
+  and update this URL.  
+  For providing your own yum repo see e.g. https://access.redhat.com/solutions/3176811
 
 ## Huge Pages
 
@@ -33,7 +41,7 @@ oc -n openshift-machine-config-operator wait machineconfigpools worker --for con
 The realtime kernel will be installed using MachineConfig, which installs a new systemd unit, which runs a script.
 The template for the `MachineConfig` placed under `manifests/templates` and the script located in `assets`. The actual manifest is created by running `make generate`,
 which will base64 encode the script and put it into the template. The result is stored under `manifests/generated/11-machine-config-worker-rt-kernel.yaml`.
-
+  
 ## Topology Manager
 
 To enable the topology manager, you should:

--- a/features/performance/assets/rt-kernel-patch.sh
+++ b/features/performance/assets/rt-kernel-patch.sh
@@ -2,16 +2,25 @@
 
 set -euo pipefail
 
-if [[ ! -f /etc/yum.repos.d/rhel.repo ]]
+REPO_DIR="/etc/yum.repos.d"
+RT_REPO="${REPO_DIR}/rt-kernel.repo"
+
+# Enable yum repo
+if [[ -f $RT_REPO ]]
 then
-    # Enable yum repo
-    mkdir -p /etc/yum.repos.d
-    cat > /etc/yum.repos.d/rhel.repo <<EOF
+  # The env var might have been changed, so always create new rt repo
+  rm $RT_REPO
+fi
+
+mkdir -p $REPO_DIR
+cat > $RT_REPO <<EOF
 [rt]
 baseurl=${RT_REPO_URL}
 gpgcheck=0
 EOF
-fi
+
+# update cache
+rpm-ostree refresh-md -f
 
 # Install patched microcode
 # see https://src.osci.redhat.com/rpms/microcode_ctl/pull-request/9
@@ -20,6 +29,7 @@ if [[ $replacedPackages =~ "microcode_ctl" ]]
 then
     echo "microcode_ctl patch already installed"
 else
+    echo "Installing microcode_ctl patch"
     rpm-ostree override replace ${MICROCODE_URL}
 fi
 
@@ -27,8 +37,18 @@ fi
 kernel=$(uname -a)
 if [[ $kernel =~ "PREEMPT RT" ]]
 then
-    # TODO: check for RT kernel updates
-    echo "RT kernel already installed"
+    echo "RT kernel already installed, checking for updates"
+    rpm-ostree upgrade --unchanged-exit-77
+    if [[ $? -eq 77 ]]
+    then
+      echo "No update available, nothing to do"
+    else
+      echo "RT kernel updated, rebooting"
+      systemctl reboot
+    fi
 else
+    echo "Installing RT kernel"
+    rpm-ostree override remove kernel{,-core,-modules,-modules-extra} --install kernel-rt-core --install kernel-rt-modules --install kernel-rt-modules-extra
+    echo "Rebooting"
     systemctl reboot
 fi

--- a/features/performance/hack/generate.sh
+++ b/features/performance/hack/generate.sh
@@ -19,7 +19,9 @@ mkdir -p ${MANIFESTS_GENERATED_DIR}
     fi
 
     export RT_KERNEL_BASE64="$(base64 -w 0 ${ASSETS_DIR}/rt-kernel-patch.sh)"
-    
+    export MICROCODE_URL=${MICROCODE_URL:-http://file.rdu.redhat.com/~walters/microcode_ctl-20190918-3.rhcos.1.el8.x86_64.rpm}
+    export RT_REPO_URL=${RT_REPO_URL:-http://download-node-02.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.1.1/compose/RT/x86_64/os}
+
     for template in $(ls ${TEMPLATES_DIR}); do
         name="$(basename ${template} .in)"
         envsubst < ${TEMPLATES_DIR}/${template} > ${MANIFESTS_GENERATED_DIR}/${name}

--- a/features/performance/manifests/templates/11-machine-config-worker-rt-kernel.yaml.in
+++ b/features/performance/manifests/templates/11-machine-config-worker-rt-kernel.yaml.in
@@ -31,11 +31,11 @@ spec:
                       Before=kubelet.service
 
                       [Service]
-                      Type=exec
+                      Type=oneshot
                       RemainAfterExit=true
 
-                      Environment=MICROCODE_URL=http://file.rdu.redhat.com/~walters/microcode_ctl-20190918-3.rhcos.1.el8.x86_64.rpm
-                      Environment=RT_REPO_URL=http://download-node-02.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.1.1/compose/RT/x86_64/os
+                      Environment=MICROCODE_URL=${MICROCODE_URL}
+                      Environment=RT_REPO_URL=${RT_REPO_URL}
 
                       ExecStart=/usr/local/bin/rt-kernel-patch.sh
 


### PR DESCRIPTION
Some improvements:
- always create yum repo config, in case env var coming from MC changes
- support rt kernel updates
- updated Readme with info about config options `MICROCODE_URL` and `RT_REPO_URL`

Also fixes the actual installation of the RT kernel, got lost yesterday somehow