### PR TITLE
Add initial owners file to check the interaction with the ci robot

### DIFF
--- a/features/sctp/OWNERS
+++ b/features/sctp/OWNERS
@@ -1,0 +1,7 @@
+
+approvers:
+- fedepaol
+- davidvossel
+reviewers:
+- fedepaol
+- davidvossel


### PR DESCRIPTION
This is an initial version of the OWNERS file for the sctp feature, mostly to validate the interaction with the prow robot. 
Will be expanded / extended to the network people later on.