### PR TITLE
bonding: add configuration generation tool

### DIFF
--- a/features/bonding/README.md
+++ b/features/bonding/README.md
@@ -1,0 +1,54 @@
+# Bonding configuration generation
+
+## Script
+
+* [bonding.py](scripts/bonding.py)
+* [Parameters example](examples/parameters.yaml.sample)
+
+## Requirements
+
+* Python >= 3.7 (rpm: python3)
+* jinja2 (rpm: python3-jinja2)
+* pyyaml (rpm: python3-pyyaml)
+
+## Parameters file
+
+* primary: opens block for Ignition data
+  * device: name for the bonding device
+  * kernel_options: bonding kernel module parameters
+  * phy_devices: array listing the physical devices composing the bond
+  * vlans: array listing the VLAN IDs and their network configuration details
+* secondary: opens block for NMState data
+  * device: name for the bonding device
+  * config: opens block for bonding kernel module parameters
+    * mode: bonding mode (active-backup, balance-rr, ...)
+    * options: dictionary holding key/value parameters (e.g. miimon: 140)
+  * phy_devices: array listing the physical devices composing the bond
+  * vlans: array listing the VLAN IDs and their network configuration details
+  * routes: opens block for routes configuration
+    * dst: route destination
+    * metric: route metric
+    * gw: route gateway
+    * iface: route interface
+    * table: routing table ID
+  * dns: opens block for DNS resolver data
+    * search: array listing DNS domain names for looking up short host names
+    * nameservers: array listing IP addresses to be used as DNS servers
+
+## Usage
+
+* The parameters file uses two sections, `primary` and `secondary` to define _Ignition_ settings and _NMState_ details respectively
+* The script can generate, both _Ignition_ and _NMState_ configuration files at the same time using `-a|--all` or independently, using `-i|--ignition` or `-n|--nmstate`. It does all by default.
+* Using the [parameters example](examples/parameters.yaml.sample) as follows:
+
+  ```console
+  $ scripts/bonding.py -f examples/parameters.yaml.sample -t templates -o /tmp/out -a
+  $ ls -la /tmp/out
+  total 8
+  drwxrwxr-x.   2 sjr  sjr    80 Dec  4 12:28 .
+  drwxrwxrwt. 117 root root 2700 Dec  4 12:28 ..
+  -rw-rw-r--.   1 sjr  sjr   899 Dec  4 12:28 2160-nmstate-bonding-manifest.yaml
+  -rw-rw-r--.   1 sjr  sjr  1562 Dec  4 12:28 8847-ignition-bond.ign
+  ```
+
+  At this point the two files can be used to inject the configuration into the nodes.

--- a/features/bonding/examples/parameters.yaml.sample
+++ b/features/bonding/examples/parameters.yaml.sample
@@ -1,0 +1,53 @@
+---
+primary:
+  device: bond0
+  kernel_options: mode=1 fail_over_mac=2
+  phy_devices:
+    - device: ens3
+    - device: ens4
+  vlans:
+    - id: 20
+      ipv4:
+        dhcp: true
+    - id: 30
+      ipv4:
+        ip: 10.10.21.220
+        prefix: 24
+        gw: 10.10.21.1
+      ipv6:
+        ip: 2001:db9::1:1
+        prefix: 64
+secondary:
+  device: bond1
+  config:
+    mode: active-backup
+    options:
+      miimon: 140
+  phy_devices:
+    - device: ens8
+    - device: ens9
+  vlans:
+    - id: 20
+      ipv4:
+        dhcp: true
+    - id: 30
+      ipv4:
+        - ip: 10.10.20.220
+          prefix: 24
+      ipv6:
+        - ip: 2001:db8::1:1
+          prefix: 64
+  routes:
+    - dst: 0.0.0.0/0
+      gw: 10.10.20.1
+      iface: bond1.30
+    - dst: ff00::/8
+      gw: 2001:db8::1:2/64
+      iface: bond1.30
+  dns:
+    search:
+      - example.com
+      - example.org
+    nameservers:
+      - 2001:4860:4860::8888
+      - 8.8.8.8

--- a/features/bonding/scripts/bonding.py
+++ b/features/bonding/scripts/bonding.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python
+
+import jinja2
+import yaml
+import sys
+import argparse
+import os
+import base64
+import random
+from typing import NoReturn, Text
+
+TEMPLATE_DIR = os.path.dirname(sys.argv[0]) + '/../templates/'
+
+
+class BondingTemplator(object):
+
+    def __init__(self, templates_dir: str):
+        self.__templates_dir = templates_dir
+        self.__iface_templ = 'ifcfg-iface.j2'
+        self.__vlan_templ = 'ifcfg-bondX.vlan.j2'
+        self.__bond_templ = 'ifcfg-bondX.j2'
+        self.__ign_templ = 'bondX-ignition.j2'
+        self.__nmstate_templ = 'nmstate-bondX.yaml.j2'
+        try:
+            self.__env = jinja2.Environment(
+                loader=jinja2.FileSystemLoader(self.__templates_dir),
+                keep_trailing_newline=True
+            )
+        except jinja2.TemplateError as e:
+            print(
+                "error loading templates directory",
+                self.__templates_dir, ":", e)
+            sys.exit(1)
+
+    def __process_phy_devices(
+            self, phy_devices: list, bond_device: str) -> list:
+        results = list()
+        for dev in phy_devices:
+            try:
+                dev['bond_device'] = bond_device
+                template = self.__env.get_template(self.__iface_templ)
+                output = template.render(dev)
+                dev['b64'] = base64.b64encode(
+                    output.encode('utf-8')).decode('utf-8')
+                dev['filename'] = 'ifcfg-' + dev.get('device')
+                results.append(dev)
+            except jinja2.TemplateError as e:
+                print("error processing", self.__iface_templ, ":", e)
+                sys.exit(1)
+        return results
+
+    def __process_vlans(
+            self, vlans: list, bond_device: str) -> list:
+        results = list()
+        for vlan in vlans:
+            try:
+                vlan['bond_device'] = bond_device
+                template = self.__env.get_template(self.__vlan_templ)
+                output = template.render(vlan)
+                vlan['b64'] = base64.b64encode(
+                    output.encode('utf-8')).decode('utf-8')
+                vlan['filename'] = 'ifcfg-' + vlan.get('bond_device') + '.' \
+                    + str(vlan.get('id'))
+                del(vlan['bond_device'])
+                results.append(vlan)
+            except jinja2.TemplateError as e:
+                print("error processing", self.__vlan_templ, ":", e)
+                sys.exit(1)
+        return results
+
+    def __generate_ifcfg_files(self, template_data: dict) -> dict:
+        try:
+            bond_templ = self.__env.get_template(self.__bond_templ)
+            bond_output = bond_templ.render(template_data)
+        except jinja2.TemplateError as e:
+            print("error processing", self.__bond_templ, ":", e)
+            sys.exit(1)
+
+        bond_device = template_data.get('device')
+        template_data['b64'] = base64.b64encode(
+            bond_output.encode('utf-8')).decode('utf-8')
+        template_data['filename'] = 'ifcfg-' + template_data.get('device')
+
+        phy_devices = template_data.get('phy_devices')
+        template_data['phy_devices'] = self.__process_phy_devices(
+            phy_devices, bond_device)
+
+        vlans = template_data.get('vlans')
+        template_data['vlans'] = self.__process_vlans(vlans, bond_device)
+        return template_data
+
+    def __render_ignition(self, parameters: dict) -> Text:
+        try:
+            template = self.__env.get_template(self.__ign_templ)
+            return template.render(parameters)
+        except jinja2.TemplateError as e:
+            print("error processing", self.__ign_templ, ":", e)
+            sys.exit(1)
+
+    def __render_nmstate(self, parameters: dict) -> Text:
+        try:
+            template = self.__env.get_template(self.__nmstate_templ)
+            return template.render(parameters)
+        except jinja2.TemplateError as e:
+            print("error processing", self.__nmstate_templ, ":", e)
+            sys.exit(1)
+
+    def __write_template_to_file(self, data: Text, outfile: str) -> NoReturn:
+        try:
+            with open(outfile, 'w') as file:
+                file.write(data)
+            return
+        except OSError as e:
+            print("Error writing", outfile, ":", e)
+            sys.exit(1)
+
+    def write_nmstate_to_file(self, data: Text, outdir: str) -> NoReturn:
+        outfile = outdir + '/' + str(random.randint(1, 10000)) + \
+            '-nmstate-bonding-manifest.yaml'
+        self.__write_template_to_file(data, outfile)
+
+    def write_ignition_to_file(self, data: Text, outdir: str) -> NoReturn:
+        outfile = outdir + '/' + str(random.randint(1, 10000)) + \
+            '-ignition-bond.ign'
+        self.__write_template_to_file(data, outfile)
+
+    def read_parameters_file(self, params_file: str) -> dict:
+        try:
+            with open(params_file) as file:
+                parameters = yaml.load(file, Loader=yaml.FullLoader)
+                return parameters
+        except yaml.YAMLError as e:
+            print('error parsing parameters file:', e)
+            sys.exit(-1)
+
+    def generate_ignition(self, params: dict) -> Text:
+        primary = params.get('primary')
+        if not primary:
+            print('No primary bond data found')
+            sys.exit(1)
+
+        processed_data = self.__generate_ifcfg_files(primary)
+        return self.__render_ignition(processed_data)
+
+    def generate_nmstate(self, params: dict) -> Text:
+        secondary = params.get('secondary')
+        if not secondary:
+            print('No secondary bond data found')
+            sys.exit(1)
+
+        return self.__render_nmstate(secondary)
+
+    def generate_all(self, params: dict) -> dict:
+        result = dict()
+        result['ignition'] = self.generate_ignition(params)
+        result['nmstate'] = self.generate_nmstate(params)
+        return result
+
+
+def main() -> NoReturn:
+    parser = argparse.ArgumentParser(
+        description="Generate bonding configuration files.",
+        epilog="One of the three available modes is \
+            required, all, ignition or nmstate")
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-i', '--ignition', default=False, action='store_true',
+                       help='mode Ignition, creates only Ignition file')
+    group.add_argument('-n', '--nmstate', default=False, action='store_true',
+                       help='mode NMState, create only NMState file')
+    group.add_argument('-a', '--all', default=False, action='store_true',
+                       help='mode all, create Ignition and NMState files')
+    parser.add_argument('-f', '--param-file', required=True, type=str,
+                        help='path to parameters file')
+    parser.add_argument('-o', '--output-dir', default='out', type=str)
+    parser.add_argument('-t', '--templates', default=TEMPLATE_DIR, type=str,
+                        help='path to the templates directory')
+    args = parser.parse_args()
+
+    if not (args.ignition or args.nmstate or args.all):
+        parser.print_help()
+        sys.exit(1)
+
+    if not os.path.isdir(args.output_dir):
+        os.mkdir(args.output_dir)
+
+    if not os.path.isdir(args.templates):
+        print('Could not locate templates dir', args.templates)
+        sys.exit(1)
+
+    bonding = BondingTemplator(args.templates)
+
+    params = bonding.read_parameters_file(args.param_file)
+
+    if args.ignition:
+        contents = bonding.generate_ignition(params)
+        bonding.write_ignition_to_file(contents, args.output_dir)
+    elif args.nmstate:
+        contents = bonding.generate_nmstate(params)
+        bonding.write_nmstate_to_file(contents, args.output_dir)
+    else:
+        result = bonding.generate_all(params)
+        bonding.write_ignition_to_file(result.get('ignition'), args.output_dir)
+        bonding.write_nmstate_to_file(result.get('nmstate'), args.output_dir)
+
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/features/bonding/templates/bondX-ignition.j2
+++ b/features/bonding/templates/bondX-ignition.j2
@@ -1,0 +1,30 @@
+{
+  "ignition": { "version": "2.2.0" },
+  "storage": {
+    "files": [{
+      "filesystem": "root",
+      "path": "/etc/sysconfig/network-scripts/{{ filename }}",
+      "mode": 420,
+      "contents": { "source": "data:text/plain;charset=utf-8;base64,{{ b64|string }}" }
+    },
+    {%- for vlan in vlans %}
+    {
+      "filesystem": "root",
+      "path": "/etc/sysconfig/network-scripts/{{ vlan.filename }}",
+      "mode": 420,
+      "contents": { "source": "data:text/plain;charset=utf-8;base64,{{ vlan.b64 }}" }
+    },{%- endfor -%}
+    {%- for dev in phy_devices %}
+    {
+      "filesystem": "root",
+      "path": "/etc/sysconfig/network-scripts/{{ dev.filename }}",
+      "mode": 420,
+      "contents": { "source": "data:text/plain;charset=utf-8;base64,{{ dev.b64 }}" }
+    {%- if not loop.last %}
+    },
+    {%- else %}
+    }]
+    {%- endif -%}
+    {%- endfor %}
+  }
+}

--- a/features/bonding/templates/ifcfg-bondX.j2
+++ b/features/bonding/templates/ifcfg-bondX.j2
@@ -1,0 +1,5 @@
+DEVICE="{{ device }}"
+ONBOOT="yes"
+BOOTPROTO=none
+BONDING_OPTS="{{ kernel_options }}"
+TYPE=Bond

--- a/features/bonding/templates/ifcfg-bondX.vlan.j2
+++ b/features/bonding/templates/ifcfg-bondX.vlan.j2
@@ -1,0 +1,27 @@
+DEVICE="{{ bond_device }}.{{ id }}"
+{%- if ipv4 %}
+  {%- if ipv4.dhcp %}
+BOOTPROTO="dhcp"
+  {%- else %}
+BOOTPROTO=none
+IPADDR={{ ipv4.ip }}
+PREFIX={{ ipv4.prefix }}
+    {%- if ipv4.gw %}
+GATEWAY={{ ipv4.gw }}
+    {%- endif %}
+  {%- endif %}
+{%- endif %}
+{%- if ipv6 %}
+IPV6INIT=yes
+  {%- if ipv6.dhcp %}
+IPV6_AUTOCONF="no"
+DHCPV6C=”yes”
+  {%- else %}
+IPV6ADDR={{ ipv6.ip }}/{{ ipv6.prefix }}
+    {%- if ipv6.gw %}
+IPV6_DEFAULTGW={{ ipv6.gw }}
+    {%- endif %}
+  {%- endif %}
+{%- endif %}
+ONBOOT="yes"
+VLAN="yes"

--- a/features/bonding/templates/ifcfg-iface.j2
+++ b/features/bonding/templates/ifcfg-iface.j2
@@ -1,0 +1,6 @@
+NAME="{{ device }}"
+TYPE=Ethernet
+ONBOOT=yes
+DEVICE="{{ device }}"
+SLAVE=yes
+MASTER="{{ bond_device }}"

--- a/features/bonding/templates/nmstate-bondX.yaml.j2
+++ b/features/bonding/templates/nmstate-bondX.yaml.j2
@@ -1,0 +1,92 @@
+---
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: {{ device }}-nncp-{{ range(1,10000) |random }}
+spec:
+  desiredState:
+    interfaces:
+    - name: {{ device }}
+      type: bond
+      state: up
+      link-aggregation:
+        mode: {{ config.mode }}
+        options:
+          {%- for opt, value in config.options.items() %}
+          {{ opt }}: '{{ value }}'
+          {%- endfor %}
+        slaves:
+        {%- for dev in phy_devices %}
+        - {{ dev.device }}
+        {%- endfor %}
+    {%- for vlan in vlans %}
+    - name: {{ device }}.{{ vlan.id }}
+      type: vlan
+      state: up
+      {%- if vlan.ipv4 %}
+      ipv4:
+        {%- if vlan.ipv4.dhcp %}
+        auto-dns: false
+        auto-gateway: false
+        auto-routes: false
+        dhcp: true
+        {%- else %}
+        address:
+          {%- for address in vlan.ipv4 %}
+          - ip: {{ address.ip }}
+            prefix-length: {{ address.prefix }}
+          {%- endfor %}
+        {%- endif %}
+        enabled: true
+      {%- endif %}
+      {%- if vlan.ipv6 %}
+      ipv6:
+        {%- if vlan.ipv6.dhcp %}
+        auto-dns: false
+        auto-gateway: false
+        auto-routes: false
+        dhcp: true
+        {%- else %}
+        address:
+          {%- for address in vlan.ipv6 %}
+          - ip: {{ address.ip }}
+            prefix-length: {{ address.prefix }}
+          {%- endfor %}
+        {%- endif %}
+        enabled: true
+      {%- endif %}
+      vlan:
+        base-iface: {{ device }}
+        id: {{ vlan.id }}
+    {%- endfor %}
+    {%- if routes %}
+    routes:
+      config:
+      {%- for route in routes %}
+        - destination: {{ route.dst }}
+          {%- if route.metric %}
+          metric: {{ route.metric }}
+          {%- endif %}
+          {%- if route.gw %}
+          next-hop-address: {{ route.gw }}
+          {%- endif %}
+          {%- if route.iface %}
+          next-hop-interface: {{ route.iface }}
+          {%- endif %}
+          {%- if route.table %}
+          table-id: {{ route.table }}
+          {%- endif %}
+      {%- endfor %}
+    {%- endif %}
+    {%- if dns %}
+    dns-resolver:
+      config:
+        search:
+        {%- for domain in dns.search %}
+          - {{ domain }}
+        {%- endfor %}
+        server:
+        {%- for server in dns.nameservers %}
+          - {{ server }}
+        {%- endfor %}
+    {%- endif %}


### PR DESCRIPTION
# Description

This PR adds a small tool to generate bonding configuration, both Ignition and NMState, based on Jinja2 templates.

I hope this tool will help with #31 

## Type of change

Please select the appropriate options:

- [X] New feature (non-breaking change which adds functionality)

## Testing

So far my tests have been performed on virtual environments:

* Deployed OCP 4.3 with primary bonding device, no VLANs
* Deployed OCP 4.3 (without primary bonding), deployed NMState Kubernetes controller and configured secondary bonding device with 2 VLANs.

**Test Configuration**:

- Versions: OCP  4.3, RHCOS 4.3 QEMU image
- Hardware: VMs, Libvirt/QEMU based

