### PR TITLE
performance: generator: ensure string

### DIFF
--- a/features/performance/manifests/templates/12-kubeletconfig-worker-rt.yaml.in
+++ b/features/performance/manifests/templates/12-kubeletconfig-worker-rt.yaml.in
@@ -15,6 +15,6 @@ spec:
       memory: 500Mi
     cpuManagerPolicy: static
     cpuManagerReconcilePeriod: 5s
-    reservedSystemCPUs: ${RESERVED_CPUS}
+    reservedSystemCPUs: "${RESERVED_CPUS}"
     topologyManagerPolicy: best-effort
 # options: https://github.com/kubernetes/kubernetes/blob/release-1.14/pkg/kubelet/apis/config/types.go#L62


### PR DESCRIPTION
# Description

The KubeletConfig expects the value of "ReservedSystemCpus"
to be a string. We should ensure the manifest generator guarantees that.

Fixes # (issue)
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Tested using https://github.com/openshift-kni/baremetal-deploy/pull/52 - discovered during rebasing


**Test Configuration**:

- Versions: N/A
- Hardware: N/A

## Checklist

- [X] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [X] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
