### PR TITLE
Fixing #58

### DIFF
--- a/features/performance/hack/deploy.sh
+++ b/features/performance/hack/deploy.sh
@@ -17,7 +17,7 @@ for mcp in ${mcps}; do
 done
 
 # apply manifests
-oc apply -R ${MANIFESTS_GENERATED_DIR}
+oc apply -Rf ${MANIFESTS_GENERATED_DIR}
 
 # unpause all machine config pools
 for mcp in ${mcps}; do


### PR DESCRIPTION
# Description

Deployment of performance feature is broken, must work using just a `make` command and needs the flags `-Rf` to work properly not just `-R`

Fixes #58 

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

```
git clone $GitRepo
cd $GitRepo/features/performance
ISOLATED_CPUS=2 RESERVED_CPUS=2 make
```

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
