### PR TITLE
Make it possible to choose the features to run functests against

### DIFF
--- a/features/Makefile
+++ b/features/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: test, ginkgo
 
-export FEATURES?=sctp 
+export FEATURES?=sctp
 
 deps:
 	go mod tidy && \
@@ -11,7 +11,9 @@ ginkgo:
 	go get github.com/onsi/ginkgo/ginkgo
 
 functests: ginkgo
-	GOFLAGS=-mod=vendor ginkgo functests -- -junit /tmp/artifacts/unit_report.xml
+	FOCUS=$$(echo $(FEATURES) | tr ' ' '|') && \
+	echo "Focusing on $$FOCUS" && \
+	GOFLAGS=-mod=vendor ginkgo functests --focus=$$FOCUS -- -junit /tmp/artifacts/unit_report.xml
 
 unittests:
 	GO_PACKAGES=$$(go list ./...| grep -v /functests); \


### PR DESCRIPTION
# Description

We want to be able to be modular in terms of features we test, the same way we are in terms of deployment. With this PR, the same FEATURES env variable that drives the features to be deployed will drive the functests to execute.

The final workflow would be:
`export FEATURES="feat1 feat2" && make deploy && make functests`

This will allow us to have per feature gating tests (focusing on the single feature) but also global e2e tests that will eventually run as a periodic job

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Run `export FEATURES=sctp && make deploy && make functests` against a cluster

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
