### PR TITLE
RT kernel script should exit with code 0 on success

### DIFF
--- a/features/performance/assets/rt-kernel-patch.sh
+++ b/features/performance/assets/rt-kernel-patch.sh
@@ -42,6 +42,7 @@ then
     if [[ $? -eq 77 ]]
     then
       echo "No update available, nothing to do"
+      exit 0
     else
       echo "RT kernel updated, rebooting"
       systemctl reboot


### PR DESCRIPTION
# Description

Currently the RT kernel script exits with the error code 77 once no upgrade is available for the kernel,
```
Dec 12 14:05:08 worker-0 rt-kernel-patch.sh[1614]: Enabled rpm-md repositories: rt
Dec 12 14:05:08 worker-0 rt-kernel-patch.sh[1614]: Updating metadata for 'rt'...done
Dec 12 14:05:08 worker-0 rt-kernel-patch.sh[1614]: rpm-md repo 'rt'; generated: 2019-12-12T09:45:55Z
Dec 12 14:05:08 worker-0 rt-kernel-patch.sh[1614]: Importing rpm-md...done
Dec 12 14:05:09 worker-0 rt-kernel-patch.sh[1614]: microcode_ctl patch already installed
Dec 12 14:05:09 worker-0 rt-kernel-patch.sh[1614]: RT kernel already installed, checking for updates
Dec 12 14:05:13 worker-0 rt-kernel-patch.sh[1614]: Checking out tree f02dbe9...done
Dec 12 14:05:13 worker-0 rt-kernel-patch.sh[1614]: Enabled rpm-md repositories: rt
Dec 12 14:05:13 worker-0 rt-kernel-patch.sh[1614]: rpm-md repo 'rt' (cached); generated: 2019-12-12T09:45:55Z
Dec 12 14:05:13 worker-0 rt-kernel-patch.sh[1614]: Importing rpm-md...done
Dec 12 14:05:13 worker-0 rt-kernel-patch.sh[1614]: Resolving dependencies...done
Dec 12 14:05:13 worker-0 rt-kernel-patch.sh[1614]: No upgrade available.
Dec 12 14:05:13 worker-0 systemd[1]: rt-kernel.service: Main process exited, code=exited, status=77/NOPERM
Dec 12 14:05:13 worker-0 systemd[1]: rt-kernel.service: Failed with result 'exit-code'.
Dec 12 14:05:13 worker-0 systemd[1]: Failed to start RT kernel patch.
```

## Type of change

Please select the appropriate options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [X] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>