### PR TITLE
Add dockerfile for the OCP CI build image

### DIFF
--- a/features/Dockefile.buildimage
+++ b/features/Dockefile.buildimage
@@ -1,0 +1,27 @@
+FROM fedora:31
+ENV GOPATH /go
+ENV GOBIN /go/bin
+ENV GOCACHE /go/.cache
+ENV PATH=$PATH:$GOPATH/bin
+ENV GOVERSION golang-1.13.5-1.fc31
+
+# rpms required for building and running test suites
+RUN dnf -y install \
+    $GOVERSION \
+    make \
+    tar \
+    && dnf clean all
+
+# get required golang tools and OC client
+RUN go get github.com/onsi/ginkgo/ginkgo && \
+    go get github.com/onsi/gomega/... && \
+    go get -u golang.org/x/lint/golint && \
+    export latest_oc_client_version=$(curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/ 2>/dev/null | grep -o \"openshift-client-linux-4.*tar.gz\" | tr -d \") && \
+    curl -JL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/${latest_oc_client_version} -o oc.tar.gz && \
+    tar -xzvf oc.tar.gz && \
+    mv oc /usr/local/bin/oc && \
+    rm -f oc.tar.gz
+
+WORKDIR /src/
+
+ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
# Description

Openshift CI allows to check out our repo in a src image, optionally provided by a
Dockerfile.
We have an issue right now (described here https://github.com/openshift/release/pull/6395 ) because the oc command shipped with the image provided by the ocp CI does not support applying all the files in a given folder.
With this PR we provide a dockerfile that can be used to produce an image in place of the one provided by the CI.


Fixes # (issue)

## Type of change

Please select the appropiate options:

- [c ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ x ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ x ] PRs should not be merged unless positively reviewed.
