### PR TITLE
Fix failing tests due to wrong initialization

### DIFF
--- a/features/functests/performance/performance.go
+++ b/features/functests/performance/performance.go
@@ -27,10 +27,10 @@ var _ = Describe("performance", func() {
 	})
 
 	var _ = Context("RT Kernel Arguments", func() {
-		nodes, err := clients.K8s.CoreV1().Nodes().List(metav1.ListOptions{
-			LabelSelector: "node-role.kubernetes.io/worker=",
-		})
 		It("Nodes should contain kernel arguments set by machine configuration", func() {
+			nodes, err := clients.K8s.CoreV1().Nodes().List(metav1.ListOptions{
+				LabelSelector: "node-role.kubernetes.io/worker=",
+			})
 			Expect(err).ToNot(HaveOccurred())
 			for _, node := range nodes.Items {
 				mcd, err := mcdForNode(&node)
@@ -47,10 +47,10 @@ var _ = Describe("performance", func() {
 	})
 
 	var _ = Context("Pre boot tuning setup", func() {
-		nodes, err := clients.K8s.CoreV1().Nodes().List(metav1.ListOptions{
-			LabelSelector: "node-role.kubernetes.io/worker=",
-		})
 		It("Should contain a custome initrd image in boot loader", func() {
+			nodes, err := clients.K8s.CoreV1().Nodes().List(metav1.ListOptions{
+				LabelSelector: "node-role.kubernetes.io/worker=",
+			})
 			Expect(err).ToNot(HaveOccurred())
 			for _, node := range nodes.Items {
 				mcd, err := mcdForNode(&node)


### PR DESCRIPTION
# Description
Fix performance functest that introduced wrong initialization when starting test suite.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
