### PR TITLE
Put the --focus parameter before the folder, otherwise it's ignored.

### DIFF
--- a/features/Makefile
+++ b/features/Makefile
@@ -10,7 +10,7 @@ deps-update:
 functests:
 	FOCUS=$$(echo $(FEATURES) | tr ' ' '|') && \
 	echo "Focusing on $$FOCUS" && \
-	GOFLAGS=-mod=vendor ginkgo functests --focus=$$FOCUS -- -junit /tmp/artifacts/unit_report.xml
+	GOFLAGS=-mod=vendor ginkgo --focus=$$FOCUS functests -- -junit /tmp/artifacts/unit_report.xml
 
 .PHONY: unittests
 unittests:


### PR DESCRIPTION
# Description

If the --focus parameter gets passed after the folder, it gets ignored and make functests always run the whole suite.

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ x ] Run `FEATURES="sctp" make functests` locally
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ x ] PRs should not be merged unless positively reviewed.
