### PR TITLE
Disable functests for performance until stable

### DIFF
--- a/features/Makefile
+++ b/features/Makefile
@@ -1,5 +1,5 @@
 
-export FEATURES?=mcp performance sctp
+export FEATURES?=mcp sctp
 
 .PHONY: deps-update
 deps-update:


### PR DESCRIPTION
# Description
Disable functests for performance until the tests are aligned and stable against deployment
