### PR TITLE
Removed microcode_ctl patch

### DIFF
--- a/features/hack/common.sh
+++ b/features/hack/common.sh
@@ -22,5 +22,4 @@ RESERVED_CPUS=${RESERVED_CPUS:-}
 NON_ISOLATED_CPUS=${NON_ISOLATED_CPUS:-}
 
 # RT kernel parameters
-MICROCODE_URL=${MICROCODE_URL:-http://file.rdu.redhat.com/~walters/microcode_ctl-20190918-3.rhcos.1.el8.x86_64.rpm}
 RT_REPO_URL=${RT_REPO_URL:-http://download-node-02.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.1.1/compose/RT/x86_64/os}

--- a/features/performance/README.md
+++ b/features/performance/README.md
@@ -15,10 +15,6 @@ This is a list of environment variables that you should export before running `m
 - `NON_ISOLATED_CPUS` - CPU's that you want to reserve for OS system tasks.
 - `RESERVED_CPUS` - CPU's that you want to reserve for the system and does not use for containers workloads.
 - `HUGEPAGES_NUMBER` - Number of 1Gb hugepages to enable.
-- `MICROCODE_URL` - the location of the patched microcode_ctl RPM, as long as it is not part of RHCOS yet.  
-  Defaults to a RH internal URL. For deployments outside the RH network provide the RPM on a reachable host and
-  update this URL.  
-  See the [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1766178) for more information on this.
 - `RT_REPO_URL` - the location of a yum repo which provides the RT kernel RPMs as long as they are not part of RHCOS yet.  
   Defaults to a RH internal URL. For deployments outside the RH network provide a yum repo on a reachable host
   and update this URL.  

--- a/features/performance/assets/rt-kernel-patch.sh
+++ b/features/performance/assets/rt-kernel-patch.sh
@@ -22,17 +22,6 @@ EOF
 # update cache
 rpm-ostree refresh-md -f
 
-# Install patched microcode
-# see https://src.osci.redhat.com/rpms/microcode_ctl/pull-request/9
-replacedPackages=$(rpm-ostree status --json | jq '.deployments[] | select(.booted == true) | ."layered-commit-meta"."rpmostree.replaced-base-packages"')
-if [[ $replacedPackages =~ "microcode_ctl" ]]
-then
-    echo "microcode_ctl patch already installed"
-else
-    echo "Installing microcode_ctl patch"
-    rpm-ostree override replace ${MICROCODE_URL}
-fi
-
 trap '{ if [[ $? -eq 77 ]]; then echo "No update available, nothing to do"; exit 0; else exit $?; fi }' EXIT
 
 # Swap to RT kernel

--- a/features/performance/generate.sh
+++ b/features/performance/generate.sh
@@ -32,7 +32,6 @@ fi
         exit 1
     fi
 
-    export MICROCODE_URL
     export RT_REPO_URL
     export RT_KERNEL_BASE64="$(base64 -w 0 ${PERFORMANCE_ASSETS_DIR}/rt-kernel-patch.sh)"
     export PRE_BOOT_BASE64="$(base64 -w 0 ${PERFORMANCE_ASSETS_DIR}/pre-boot-tuning.sh)"

--- a/features/performance/manifests/templates/11-machine-config-worker-rt-kernel.yaml.in
+++ b/features/performance/manifests/templates/11-machine-config-worker-rt-kernel.yaml.in
@@ -34,7 +34,6 @@ spec:
                       Type=oneshot
                       RemainAfterExit=true
 
-                      Environment=MICROCODE_URL=${MICROCODE_URL}
                       Environment=RT_REPO_URL=${RT_REPO_URL}
 
                       ExecStart=/usr/local/bin/rt-kernel-patch.sh


### PR DESCRIPTION
# Description

Removed microcode_ctl patch from rt kernel script. Not needed anymore, it is included in OCP 4.3 now.

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Test for checking for the latest microcode_ctl version:

```
$ oc get clusterversion
NAME      VERSION                             AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.3.0-0.nightly-2019-12-18-105351   True        False         101m    Cluster version is 4.3.0-0.nightly-2019-12-18-105351

$ oc debug node/ip-10-0-154-50.ec2.internal
Starting pod/ip-10-0-154-50ec2internal-debug ...
To use host binaries, run `chroot /host`
Pod IP: 10.0.154.50
If you don't see a command prompt, try pressing enter.

sh-4.2# chroot /host

sh-4.4# rpm -qa | grep microcode
microcode_ctl-20190618-1.20191115.3.el8_1.x86_64
``` 

Also tested new MachineConfig on a OCP cluster on gcp.

**Test Configuration**:

- Versions: OCP  4.3.0-0.nightly-2019-12-18-105351 on AWS (tested for microcode_ctl RPM only) / 4.3.0-0.nightly-2019-12-18-145749 on GCP (tested rt kernel MachineConfig with updated script)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
