### PR TITLE
kubernetes-nmstate:added node config examples to README.md

### DIFF
--- a/features/kubernetes-nmstate/README.md
+++ b/features/kubernetes-nmstate/README.md
@@ -81,3 +81,46 @@ For testing you can use the `./testing.sh` script in this folder.
 The test will create a bond interface with the name `bond1` and attach `ens8` and `ens9` as the slave interfaces.
 
 *Note:* You can change the bond name and the slave interface names by editing the `myenv.file` file.
+
+## Node configuration examples
+
+### IP configuration
+
+```
+10: bond1: <BROADCAST,MULTICAST,MASTER,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
+    link/ether XX:XX:XX:XX:XX:XX brd ff:ff:ff:ff:ff:ff
+    inet 192.X.X.100/24 brd 192.X.X.255 scope global noprefixroute bond1
+       valid_lft forever preferred_lft forever
+11: bond1.20@bond1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
+    link/ether XX:XX:XX:XX:XX:XX brd ff:ff:ff:ff:ff:ff
+    inet 192.X.Y.100/24 brd 192.X.Y.255 scope global noprefixroute bond1.20
+       valid_lft forever preferred_lft forever
+```
+
+### Bond configuration
+
+```
+Ethernet Channel Bonding Driver: v3.7.1 (April 27, 2011)
+
+Bonding Mode: load balancing (round-robin)
+MII Status: up
+MII Polling Interval (ms): 140
+Up Delay (ms): 0
+Down Delay (ms):
+
+Slave Interface: enp3s0f2
+MII Status: up
+Speed: 1000 Mbps
+Duplex: full
+Link Failure Count: 0
+Permanent HW addr: XX:XX:XX:XX:XX:XX
+Slave queue ID: 0
+
+Slave Interface: enp3s0f3
+MII Status: up
+Speed: 1000 Mbps
+Duplex: full
+Link Failure Count: 0
+Permanent HW addr: XX:XX:XX:XX:XX:XX
+Slave queue ID: 0
+```


### PR DESCRIPTION
# Description

feature kubernetes-nmstate: added node configuration examples to README.m

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing

Since its documentation enhancement, no testing is required

## Checklist

- [x] I have performed a self-review of my own code
- [x] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
