### PR TITLE
Provide a value for HUGEPAGES_NUMBER to be able to run the tests

### DIFF
--- a/features/hack/test_env.sh
+++ b/features/hack/test_env.sh
@@ -4,6 +4,7 @@
 export ISOLATED_CPUS=1
 export RESERVED_CPUS=0
 export NON_ISOLATED_CPUS=0
+export HUGEPAGES_NUMBER=4
 
 WORKER_NODE=$(oc get nodes --no-headers -o name -l node-role.kubernetes.io/worker="" | head -n1)
 oc label $WORKER_NODE node-role.kubernetes.io/worker-rt=""


### PR DESCRIPTION
Before running tests, we source hack/test_env.sh to provide all necessary env variables.
The performance/generate.sh script fails if the HUGEPAGES_NUMBER is not provided.
