### PR TITLE
Apply worker="" label only if not set already.

### DIFF
--- a/features/performance/deploy.sh
+++ b/features/performance/deploy.sh
@@ -11,9 +11,14 @@ if [ "${RTNODES}" == "" ] ; then
     exit 1
 fi
 
-
 # W/A for https://bugzilla.redhat.com/show_bug.cgi?id=1777150
-oc label machineconfigpool/worker worker=
+# Apply 'worker=""' label only if not set already.
+MCPWORKER=$(oc get mcp --selector=worker="" --no-headers)
+if [ "${MCPWORKER}" == "" ] ; then
+    oc label machineconfigpool/worker worker=
+else
+    echo "MCP/worker already has label 'worker='"
+fi
 
 # pause all machine config pools
 mcps=$(oc get machineconfigpool --no-headers -o name)


### PR DESCRIPTION
# Description

While re-executing 'make deploy', deploy.sh fails if the worker MCP has worker="" label already set.

```
[INFO]: deploying performance
error: 'worker' already has a value (), and --overwrite is false
make: *** [deploy] Error 1
```

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Test by re-executing 'make deploy':

```
[INFO]: deploying mcp
machineconfigpool.machineconfiguration.openshift.io/worker-rt unchanged
[INFO]: deploying performance
MCP/worker already has label 'worker='
machineconfigpool.machineconfiguration.openshift.io/master patched
machineconfigpool.machineconfiguration.openshift.io/worker patched
machineconfigpool.machineconfiguration.openshift.io/worker-rt patched
tuned.tuned.openshift.io/openshift-node-network-latency unchanged
machineconfig.machineconfiguration.openshift.io/11-worker-rt-kernel configured
machineconfig.machineconfiguration.openshift.io/11-worker-pre-boot-tuning unchanged
featuregate.config.openshift.io/cluster unchanged
kubeletconfig.machineconfiguration.openshift.io/worker-rt unchanged
machineconfig.machineconfiguration.openshift.io/12-worker-rt-kargs unchanged
tuned.tuned.openshift.io/openshift-realtime-node unchanged
machineconfigpool.machineconfiguration.openshift.io/master patched
machineconfigpool.machineconfiguration.openshift.io/worker patched
machineconfigpool.machineconfiguration.openshift.io/worker-rt patched
machineconfigpool.machineconfiguration.openshift.io/worker-rt condition met
machineconfigpool.machineconfiguration.openshift.io/worker-rt condition met
```


## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
