### PR TITLE
This commit will do the following during bridge configuration in the …

### DIFF
--- a/install-steps.md
+++ b/install-steps.md
@@ -424,18 +424,23 @@ The following steps need to be performed in order to prepare the environment.
     # You will be disconnected, but reconnect via your ssh session after running
     export PUB_CONN=<baremetal_nic_name>
     export PROV_CONN=<prov_nic_name>
-    nmcli con delete "$PROV_CONN"
-    nmcli con delete "$PUB_CONN"
-    # RHEL 8.1 appends the word "System" in front of the connection, delete in case it exists
-    nmcli con delete "System $PUB_CONN"
-    nmcli connection add ifname provisioning type bridge con-name provisioning
-    nmcli con add type bridge-slave ifname "$PROV_CONN" master provisioning
-    nmcli connection add ifname baremetal type bridge con-name baremetal
-    nmcli con add type bridge-slave ifname "$PUB_CONN" master baremetal
-    nmcli con down "$PUB_CONN";pkill dhclient;dhclient baremetal
-    nmcli connection modify provisioning ipv4.addresses 172.22.0.1/24 ipv4.method manual
-    nmcli con down provisioning
-    nmcli con up provisioning
+    nohup bash -c '
+        nmcli con down "$PROV_CONN"
+        nmcli con down "$PUB_CONN"
+        nmcli con delete "$PROV_CONN"
+        nmcli con delete "$PUB_CONN"
+        # RHEL 8.1 appends the word "System" in front of the connection, delete in case it exists
+        nmcli con down "System $PUB_CONN"
+        nmcli con delete "System $PUB_CONN"
+        nmcli connection add ifname provisioning type bridge con-name provisioning
+        nmcli con add type bridge-slave ifname "$PROV_CONN" master provisioning
+        nmcli connection add ifname baremetal type bridge con-name baremetal
+        nmcli con add type bridge-slave ifname "$PUB_CONN" master baremetal
+        nmcli con down "$PUB_CONN";pkill dhclient;dhclient baremetal
+        nmcli connection modify provisioning ipv4.addresses 172.22.0.1/24 ipv4.method manual
+        nmcli con down provisioning
+        nmcli con up provisioning
+    '
     ~~~
 <!--
     nmcli con add type bridge ifname provisioning autoconnect yes con-name provisioning stp off


### PR DESCRIPTION
…provision node if applied:

    Prevent the creation of a temporary NM connection called "Wired ..." when creating bridges.    Allow the completion of the bridge configuration even if the connection drops by wrapping the commands in nohup.

# Description

Added nohup wrapper around nmcli commands that configure the bridges on the provisioning node.
Added commands to bring the interfaces down before removing them to prevent temporary "Wired ..." connections from being created in NetworkManager.

Fixes #108 install-steps.md Drops connection when configuring bridges via ssh

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran nohup'd nmcli commands as documented.

**Test Configuration**:

- Versions: 4.3.0-0.nightly-2019-12-20-082136
- Hardware: Baremetal

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
