### PR TITLE
baremetal-prep.sh Use $HOME instead of /home/kni

### DIFF
--- a/baremetal-prep/baremetal-prep.sh
+++ b/baremetal-prep/baremetal-prep.sh
@@ -111,7 +111,7 @@ find_sshkey_file(){
      SSHKEY="$HOME/.ssh/id_rsa.pub"
   else
      SSHKEY="$HOME/.ssh/id_rsa.pub"
-     ssh-keygen -t rsa -f /home/kni/.ssh/id_rsa -N ''     
+     ssh-keygen -t rsa -f $HOME/.ssh/id_rsa -N ''     
   fi
 
 }


### PR DESCRIPTION
Signed-off-by: Johnny Bieren <jbieren@redhat.com>

# Description

Fix hardcode of /home/kni instead of $HOME in ssh-keygen for the baremetal-prep.sh script

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran script locally with change

**Test Configuration**:

- Versions: RHEL-8
- Hardware: bm

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
