### PR TITLE
baremetal-prep.sh - setup bridges before enabling services

### DIFF
--- a/baremetal-prep/baremetal-prep.sh
+++ b/baremetal-prep/baremetal-prep.sh
@@ -259,10 +259,10 @@ setup_env
 create_manifest_dir
 existing_install_config
 install_depends
+setup_bridges
 enable_services
 #disable_selinux
 setup_default_pool
-setup_bridges
 if ([ "$GENERATEINSTALLCONF" -eq "1" ]) then
   setup_installconfig
 fi


### PR DESCRIPTION
Signed-off-by: Johnny Bieren <jbieren@redhat.com>

# Description

When firewalld is enabled, the ssh connection never recovers from `sudo nmcli con down "System $MAIN_CONN";sudo pkill dhclient;sudo dhclient baremetal` 
If the bridges are set up before firewalld is enabled, the ssh connection can recover and the script can complete.

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran locally

**Test Configuration**:

- Versions: RHEL8
- Hardware: VM

## Checklist

- [X] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
