### PR TITLE
Add step to verify OCP CI release exists in mirror

### DIFF
--- a/install-steps.md
+++ b/install-steps.md
@@ -481,8 +481,9 @@ Two approaches:
 ### Choosing a OpenShift Installer Release from CI
 
 1. Go to [https://openshift-release.svc.ci.openshift.org/](https://openshift-release.svc.ci.openshift.org/) and choose a release which has passed the tests for metal.
-2. Save the release name. e.g: `4.3.0-0.nightly-2019-12-09-035405`
-3. Configure VARS
+2. Verify that the release is available in the OpenShift mirror [https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/](https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/).
+3. Save the release name. e.g: `4.3.0-0.nightly-2019-12-09-035405`
+4. Configure VARS
     ~~~sh
     export VERSION="4.3.0-0.nightly-2019-12-09-035405"
     export RELEASE_IMAGE=$(curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/$VERSION/release.txt | grep 'Pull From: quay.io' | awk -F ' ' '{print $3}' | xargs)


### PR DESCRIPTION
# Description

In the install-steps.md, we ask the user the choose an OCP CI release if they do not wish to use the latest.  Currently, we just tell them to choose a release that has passed for "metal", but this is not enough.  The release also needs to exist in the OpenShift mirror (https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/), or else the bash scripting in the steps that follow will fail.

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

None of the above: a documentation change

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

Not needed -- documentation.

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.

N/A -- documentation?
