### PR TITLE
Clear clusterconfig dir during node-prep

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/90_create_config_install_dirs.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/90_create_config_install_dirs.yml
@@ -1,4 +1,11 @@
 ---
+- name: Clear config dir (if any, in case this is a re-run)
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+  - "{{ dir }}"
+
 - name: Create config dir
   file:
     path: "{{ item }}"


### PR DESCRIPTION
# Description

For the Ansible tool, the install-config directory (commonly ~/clusterconfigs) is not cleaned in the event of a re-run of the playbook.  This causes Terraform to error-out and complain that terraform.tfstate already exists.

Fixes # https://github.com/openshift-kni/baremetal-deploy/issues/135 (issue)

## Type of change

Please select the appropiate options:

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Simply run the ansible-ipi-installer playbook, and then stop it during the `Deploy OpenShift Cluster` task.  Then try running the playbook again, and make sure it does not immediately error-out when executing the aforementioned task.

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [x ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
