### PR TITLE
Feature Enhancements of removing binaries from /usr/loca/bin and cleaning up tmp dirs

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/10_get_oc.yml
+++ b/ansible-ipi-install/roles/installer/tasks/10_get_oc.yml
@@ -1,4 +1,30 @@
 ---
+- name: Find any old tmp dirs with OpenShift related binaries
+  find:
+    paths: /tmp
+    patterns: 'ansible.*'
+    file_type: directory
+  register: tmp_results
+
+- name: Delete any old tmp dirs with OpenShift related binaries
+  file:
+    path: "{{ item['path'] }}"
+    state: absent
+  loop: "{{ tmp_results['files'] }}"
+
+- name: Find any existing /usr/local/bin OpenShift binaries
+  find:
+    paths: /usr/local/bin
+    patterns: 'oc,openshift-baremetal-install,kubectl'
+  register: binary_results
+
+- name: Remove any existing /usr/local/bin OpenShift binaries
+  file:
+    path: "{{ item['path'] }}"
+    state: absent
+  loop: "{{ binary_results['files'] }}"
+  become: yes
+
 - name: Create tmp directory to store OpenShift binaries
   tempfile:
     state: directory

--- a/ansible-ipi-install/roles/installer/tasks/20_extract_installer.yml
+++ b/ansible-ipi-install/roles/installer/tasks/20_extract_installer.yml
@@ -24,3 +24,9 @@
     mode: '0755'
     remote_src: yes
   become: yes
+
+- name: Delete tmp dir as no longer needed
+  file:
+    path: "{{ tempdir }}"
+    state: absent
+


### PR DESCRIPTION
# Description
The playbook currently takes the oc binaries (oc, openshift-baremetal-install, kubelet) and places them in your /usr/local/bin directory. However, if say you wanted to reuse this provision host to install a new version of OCP, the existing playbook would notice that there is already an existing oc, openshift-baremetal-install,kubelet binary in /usr/local/bin and not place the newly created ones in /usr/local/bin. Solution is to create logic that checks if those files exist, and if they do, remove them prior to untarring the new binaries to be placed in the /usr/local/bin Fixes #145  

Right now when the ansible-ipi-installer kicks off it creates a tmp directory that stores the oc binaries (oc, kubelet, openshift-baremetal-install). However, if an error occurred during deployment, this tmp file isn't cleaned up. Add logic that checks if these tmp dirs exist and remove them in order to save space on the local HD. Fixes #144 

Fixes # (issue) #144 #145 

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
