### PR TITLE
adding networkType OVNKubernetes as default during installs

### DIFF
--- a/ansible-ipi-install/README.md
+++ b/ansible-ipi-install/README.md
@@ -269,6 +269,9 @@ cluster=""
 extcidrnet=""
 # An IP reserved on the baremetal network. 
 dnsvip=""
+# Network Type (OpenShiftSDN or OVNKubernetes). Playbook defaults to OVNKubernetes.
+# Uncomment below for OpenShiftSDN
+#network_type="OpenShiftSDN"
 # A copy of your pullsecret from https://cloud.redhat.com/openshift/install/metal/user-provisioned
 pullsecret=""
 

--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -42,6 +42,9 @@ cluster=""
 extcidrnet=""
 # An IP reserved on the baremetal network. 
 dnsvip=""
+# Network Type (OpenShiftSDN or OVNKubernetes). Playbook defaults to OVNKubernetes.
+# Uncomment below for OpenShiftSDN
+#network_type="OpenShiftSDN"
 # A copy of your pullsecret from https://cloud.redhat.com/openshift/install/metal/user-provisioned
 pullsecret=""
 

--- a/ansible-ipi-install/roles/node-prep/defaults/main.yml
+++ b/ansible-ipi-install/roles/node-prep/defaults/main.yml
@@ -3,3 +3,4 @@
 activation_key: ""
 org_id: ""
 release_url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview"
+network_type: "OVNKubernetes"

--- a/ansible-ipi-install/roles/node-prep/templates/install-config.j2
+++ b/ansible-ipi-install/roles/node-prep/templates/install-config.j2
@@ -4,6 +4,7 @@ metadata:
   name: {{ cluster }}
 networking:
   machineCIDR: {{ extcidrnet }}
+  networkType: {{ network_type }}
 compute:
 - name: worker
   replicas: {{ numworkers }}


### PR DESCRIPTION
Updates README, hosts.sample, main.yml, install-config.j2 to reflect change of OVN Kubernetes being default network type

Fixes #147 

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
