### PR TITLE
adding OVNKubernetes as default network type in install-steps doc

### DIFF
--- a/install-steps.md
+++ b/install-steps.md
@@ -551,6 +551,7 @@ oc adm release extract --registry-config "${pullsecret_file}" --command=$cmd --t
       name: <cluster-name>
     networking:
       machineCIDR: <public-cidr>
+      networkType: OVNKubernetes
     compute:
     - name: worker
       replicas: 2


### PR DESCRIPTION
# Description

Adding networkType: OVNKubernetes to the install-steps.md

Fixes #156 

## Type of change 
Documentation 

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
