### PR TITLE
Do not generate metal3-config for 4.4+

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/40_create_manifest.yml
+++ b/ansible-ipi-install/roles/installer/tasks/40_create_manifest.yml
@@ -23,3 +23,4 @@
     group: "{{ ansible_user }}"
     mode: '0644'
     remote_src: yes
+  when: (release_version[0]|int >= 4) and (release_version[2]|int <= 3)

--- a/ansible-ipi-install/roles/installer/tasks/40_create_manifest.yml
+++ b/ansible-ipi-install/roles/installer/tasks/40_create_manifest.yml
@@ -23,4 +23,4 @@
     group: "{{ ansible_user }}"
     mode: '0644'
     remote_src: yes
-  when: (release_version[0]|int >= 4) and (release_version[2]|int <= 3)
+  when: (release_version[0]|int == 4) and (release_version[2]|int <= 3)

--- a/ansible-ipi-install/roles/installer/tasks/main.yml
+++ b/ansible-ipi-install/roles/installer/tasks/main.yml
@@ -3,7 +3,7 @@
 - include_tasks: 10_get_oc.yml 
 - include_tasks: 20_extract_installer.yml
 - include_tasks: 30_create_metal3.yml
-  when: (release_version[0]|int >= 4) and (release_version[2]|int <= 3)
+  when: (release_version[0]|int == 4) and (release_version[2]|int <= 3)
 - include_tasks: 40_create_manifest.yml
 - include_tasks: 50_extramanifests.yml
 - include_tasks: 59_cleanup_bootstrap.yml

--- a/ansible-ipi-install/roles/installer/tasks/main.yml
+++ b/ansible-ipi-install/roles/installer/tasks/main.yml
@@ -3,6 +3,7 @@
 - include_tasks: 10_get_oc.yml 
 - include_tasks: 20_extract_installer.yml
 - include_tasks: 30_create_metal3.yml
+  when: (release_version[0]|int >= 4) and (release_version[2]|int <= 3)
 - include_tasks: 40_create_manifest.yml
 - include_tasks: 50_extramanifests.yml
 - include_tasks: 59_cleanup_bootstrap.yml


### PR DESCRIPTION
# Description

The Ansible logic should not generate a metal3-config.yaml file for 4.4+ deployments, as this ConfigMap is no longer required.

Fixes https://github.com/openshift-kni/baremetal-deploy/issues/151

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

1. Set version variable to 4.3.XXXXXX and run the playbook.  Verify that metal3-config.yaml is created in ~/clusterconfigs.
2. Remove any existing metal3-config.yaml from ~/clusterconfigs.  Set version variable to 4.4.XXXXXX and run the playbook.  Verify that that metal3-config.yaml is NOT created in ~/clusterconfigs.

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
