### PR TITLE
Add ability to specify the apivip and ingressvip in inventory/hosts

### DIFF
--- a/ansible-ipi-install/README.md
+++ b/ansible-ipi-install/README.md
@@ -270,6 +270,12 @@ cluster=""
 extcidrnet=""
 # An IP reserved on the baremetal network. 
 dnsvip=""
+# An IP reserved on the baremetal network for the API endpoint. 
+# (Optional) If not set, a DNS lookup verifies that api.<clustername>.<domain> provides an IP
+#apivip=""
+# An IP reserved on the baremetal network for the Ingress endpoint.
+# (Optional) If not set, a DNS lookup verifies that *.apps.<clustername>.<domain> provides an IP
+#ingressvip=""
 # Network Type (OpenShiftSDN or OVNKubernetes). Playbook defaults to OVNKubernetes.
 # Uncomment below for OpenShiftSDN
 #network_type="OpenShiftSDN"

--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -42,6 +42,12 @@ cluster=""
 extcidrnet=""
 # An IP reserved on the baremetal network. 
 dnsvip=""
+# An IP reserved on the baremetal network for the API endpoint. 
+# (Optional) If not set, a DNS lookup verifies that api.<clustername>.<domain> provides an IP
+#apivip=""
+# An IP reserved on the baremetal network for the Ingress endpoint.
+# (Optional) If not set, a DNS lookup verifies that *.apps.<clustername>.<domain> provides an IP
+#ingressvip=""
 # Network Type (OpenShiftSDN or OVNKubernetes). Playbook defaults to OVNKubernetes.
 # Uncomment below for OpenShiftSDN
 #network_type="OpenShiftSDN"

--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -11,6 +11,7 @@
   set_fact:
     apivip: "{{ lookup('dig', 'api.{{ cluster |quote }}.{{ domain | quote }}.')}}"
     ingressvip: "{{ lookup('dig', 'foo.apps.{{ cluster |quote }}.{{ domain | quote }}.')}}"
+  when: ((apivip is undefined) or (ingressvip is undefined) or (apivip|length == 0) or (ingressvip|length == 0))
 
 - debug: msg="The API VIP is {{ apivip }}"
 - debug: msg="The Wildcard (Ingress) VIP is {{ ingressvip }}"


### PR DESCRIPTION
# Description

add the ability to specify the apivip and ingressvip in inventory/hosts file. if both are not set, uses the lookup module. updated readme and hosts.sample accordingly to show new feature

Fixes #158 

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
