### PR TITLE
Fix install-config prov intf inject logic

### DIFF
--- a/ansible-ipi-install/roles/node-prep/templates/install-config.j2
+++ b/ansible-ipi-install/roles/node-prep/templates/install-config.j2
@@ -18,7 +18,7 @@ platform:
     apiVIP: {{ apivip }}
     ingressVIP: {{ ingressvip }}
     dnsVIP: {{ dnsvip }}
-{% if (release_version[0]|int >= 4) and (release_version[2]|int > 3) %}
+{% if (release_version[0]|int > 4) or ((release_version[0]|int == 4) and (release_version[2]|int > 3)) %}
     provisioningNetworkInterface: {{ prov_nic }}
 {% endif %}
     hosts:


### PR DESCRIPTION
# Description

*2nd version*

4.4 requires `provisioningNetworkInterface` to be present in install-config.yaml to designate the name of the provisioning interface used during deployment.  Failure to do so seems to result in a default of `ens3` being used, which won't work for every baremetal environment.  We can take `prov_nic` and inject it into the install-config j2 template to fix this problem.

Fixes https://github.com/openshift-kni/baremetal-deploy/issues/153

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

I run an ansible-ipi-install against my baremetal environment without injecting the provisioning interface name in the install-config.yaml, and I see that the deployment incorrectly defaults to `ens3`.  I then run the ansible-ipi-install again, this time with the install-config j2 template changes for injecting the provisoning nic name, and the proper interface appears within deployment objects.

**Test Configuration**:

- Versions:
- Hardware: OCTO NFVHA Supermicro lab

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
