### PR TITLE
Add support for hardwareprofile

### DIFF
--- a/ansible-ipi-install/README.md
+++ b/ansible-ipi-install/README.md
@@ -282,17 +282,18 @@ dnsvip=""
 # A copy of your pullsecret from https://cloud.redhat.com/openshift/install/metal/user-provisioned
 pullsecret=""
 
-
 # Master nodes
+# The hardware_profile is used by the baremetal operator to match the hardware discovered on the host
+# See https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md#baremetalhost-status
 [masters]
-master-0 name=master-0 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.1 provision_mac=ec:f4:bb:da:0c:58
-master-1 name=master-1 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.2 provision_mac=ec:f4:bb:da:32:88
-master-2 name=master-2 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.3 provision_mac=ec:f4:bb:da:0d:98
+master-0 name=master-0 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.1 provision_mac=ec:f4:bb:da:0c:58 hardware_profile=default
+master-1 name=master-1 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.2 provision_mac=ec:f4:bb:da:32:88 hardware_profile=default
+master-2 name=master-2 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.3 provision_mac=ec:f4:bb:da:0d:98 hardware_profile=default
 
 # Worker nodes
 [workers]
-worker-0 name=worker-0 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.4 provision_mac=ec:f4:bb:da:0c:18
-worker-1 name=worker-1 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.5 provision_mac=ec:f4:bb:da:32:28
+worker-0 name=worker-0 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.4 provision_mac=ec:f4:bb:da:0c:18 hardware_profile=unknown
+worker-1 name=worker-1 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.5 provision_mac=ec:f4:bb:da:32:28 hardware_profile=unknown
 
 # Provision Host
 [provisioner]

--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -56,15 +56,17 @@ pullsecret=""
 
 
 # Master nodes
+# The hardware_profile is used by the baremetal operator to match the hardware discovered on the host
+# See https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md#baremetalhost-status
 [masters]
-master-0 name=master-0 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.1 provision_mac=ec:f4:bb:da:0c:58
-master-1 name=master-1 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.2 provision_mac=ec:f4:bb:da:32:88
-master-2 name=master-2 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.3 provision_mac=ec:f4:bb:da:0d:98
+master-0 name=master-0 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.1 provision_mac=ec:f4:bb:da:0c:58 hardware_profile=default
+master-1 name=master-1 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.2 provision_mac=ec:f4:bb:da:32:88 hardware_profile=default
+master-2 name=master-2 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.3 provision_mac=ec:f4:bb:da:0d:98 hardware_profile=default
 
 # Worker nodes
 [workers]
-worker-0 name=worker-0 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.4 provision_mac=ec:f4:bb:da:0c:18
-worker-1 name=worker-1 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.5 provision_mac=ec:f4:bb:da:32:28
+worker-0 name=worker-0 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.4 provision_mac=ec:f4:bb:da:0c:18 hardware_profile=unknown
+worker-1 name=worker-1 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.5 provision_mac=ec:f4:bb:da:32:28 hardware_profile=unknown
 
 # Provision Host
 [provisioner]

--- a/ansible-ipi-install/roles/node-prep/templates/install-config.j2
+++ b/ansible-ipi-install/roles/node-prep/templates/install-config.j2
@@ -30,7 +30,7 @@ platform:
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}
         bootMACAddress: {{ hostvars[host]['provision_mac'] }}
-        hardwareProfile: default
+        hardwareProfile: {{ hostvars[host]['hardware_profile'] or "default" }}
 {% endfor %}
 {% for host in groups['workers'] %}
       - name: {{ hostvars[host]['name'] }}
@@ -40,7 +40,7 @@ platform:
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}
         bootMACAddress: {{ hostvars[host]['provision_mac'] }}
-        hardwareProfile: unknown
+        hardwareProfile: {{ hostvars[host]['hardware_profile'] or "unknown" }}
 {% endfor %}
 pullSecret: '{{ pullsecret }}'
 sshKey: '{{ key }}'


### PR DESCRIPTION
# Description
This allows to set different hardware profiles for masters and workers on individual basis. It defaults to the previous ones if no data is provided.

Fix #165 

## Type of change

Please select the appropriate options:

- [X] New feature (non-breaking change which adds functionality)

## Testing

Run the playbook as it is right now and the worker fails because:

```
openshift-machine-api   kni1-worker-0   error    provisioning             kni1-worker-0-r7gcg   ipmi://10.19.143.29   unknown            true     Image provisioning failed: node f7819fc2-50ee-4b25-bb9b-3269f3ffac85 command status errored: {'type': 'ImageWriteError', 'code': 500, 'message': 'Error writing image to device: Writing image to device /dev/sda failed with exit code 1. stdout: write_image.sh: Erasing existing GPT and MBR data structures from /dev/sda\n. stderr: blockdev: cannot open /dev/sda: No medium found\n', 'details': 'Writing image to device /dev/sda failed with exit code 1. stdout: write_image.sh: Erasing existing GPT and MBR data structures from /dev/sda\n. stderr: blockdev: cannot open /dev/sda: No medium found\n'}
```

**Test Configuration**:

- Versions: 4.3.1 GA
- Hardware: Bare metal

## Checklist

- [x] I have performed a self-review of my own code
- [x] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
