### PR TITLE
Check for hardware_profile in host vars

### DIFF
--- a/ansible-ipi-install/roles/node-prep/templates/install-config.j2
+++ b/ansible-ipi-install/roles/node-prep/templates/install-config.j2
@@ -30,7 +30,11 @@ platform:
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}
         bootMACAddress: {{ hostvars[host]['provision_mac'] }}
-        hardwareProfile: {{ hostvars[host]['hardware_profile'] or "default" }}
+{% if 'hardware_profile' in hostvars[host] %}
+        hardwareProfile: {{ hostvars[host]['hardware_profile'] }}
+{% else %}
+        hardwareProfile: default
+{% endif %}
 {% endfor %}
 {% for host in groups['workers'] %}
       - name: {{ hostvars[host]['name'] }}
@@ -40,7 +44,11 @@ platform:
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}
         bootMACAddress: {{ hostvars[host]['provision_mac'] }}
-        hardwareProfile: {{ hostvars[host]['hardware_profile'] or "unknown" }}
+{% if 'hardware_profile' in hostvars[host] %}
+        hardwareProfile: {{ hostvars[host]['hardware_profile'] }}
+{% else %}
+        hardwareProfile: unknown
+{% endif %}
 {% endfor %}
 pullSecret: '{{ pullsecret }}'
 sshKey: '{{ key }}'


### PR DESCRIPTION
# Description

If the user fails to include `hardware_profile` in their inventory hosts in the Ansible tool, and they happen to be using a fresh clone of the repo, then Ansible will error-out when trying to access the non-existent `hardware_profile` in the host vars during install-config.yaml generation (as the playbook has never been executed before, the cached host vars lack the `hardware_profile` attribute).  We should check that the attribute is defined before trying to reference it.

Fixes https://github.com/openshift-kni/baremetal-deploy/issues/167

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Clone the repo and create your hosts file, leaving `hardware_profile` out
- Run the playbook, and ensure the the "Generate install config" task executes without error

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
