### PR TITLE
Enable async install and looping of wait-for commands

### DIFF
--- a/ansible-ipi-install/README.md
+++ b/ansible-ipi-install/README.md
@@ -267,6 +267,29 @@ prov_ip=172.22.0.3
 # (Optional) A list of clock servers to be used in chrony by the masters and workers
 #clock_servers=["pool.ntp.org","clock.redhat.com"]
 
+# (Optional) Provide HTTP proxy settings
+#http_proxy=http://USERNAME:PASSWORD@proxy.example.com:8080
+
+# (Optional) Provide HTTPS proxy settings
+#https_proxy=https://USERNAME:PASSWORD@proxy.example.com:8080
+
+# (Optional) comma-separated list of hosts, IP Addresses, or IP ranges in CIDR format
+# excluded from proxying
+# NOTE: OpenShift does not accept '*' as a wildcard attached to a domain suffix
+# i.e. *.example.com
+# Use '.' as the wildcard for a domain suffix as shown in the example below.
+# i.e. .example.com
+#no_proxy_list="172.22.0.0/24,.example.com"
+
+# The default installer timeouts for the bootstrap and install processes may be too short for some baremetal
+# deployments. The variables below can be used to extend those timeouts.
+
+# (Optional) Increase bootstrap process timeout by N iterations.
+#increase_bootstrap_timeout=2
+
+# (Optional) Increase install process timeout by N iterations.
+#increase_install_timeout=2
+
 ######################################
 # Vars regarding install-config.yaml #
 ######################################

--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -64,6 +64,14 @@ prov_ip=172.22.0.3
 # i.e. .example.com
 #no_proxy_list="172.22.0.0/24,.example.com"
 
+# The default installer timeouts for the bootstrap and install processes may be too short for some baremetal
+# deployments. The variables below can be used to extend those timeouts.
+
+# (Optional) Increase bootstrap process timeout by N iterations.
+#increase_bootstrap_timeout=2
+
+# (Optional) Increase install process timeout by N iterations.
+#increase_install_timeout=2
 
 ######################################
 # Vars regarding install-config.yaml #

--- a/ansible-ipi-install/roles/installer/tasks/60_deploy_ocp.yml
+++ b/ansible-ipi-install/roles/installer/tasks/60_deploy_ocp.yml
@@ -8,4 +8,41 @@
 - name: Deploy OpenShift Cluster
   shell: |
     /usr/local/bin/openshift-baremetal-install --dir {{ dir }} --log-level debug create cluster
+  when:
+    - increase_bootstrap_timeout is not defined
+    - increase_install_timeout is not defined
+  tags: install
+
+- name: Deploy OpenShift Cluster with extended timeouts
+  block:
+    - name: Run OpenShift Cluster install as async task
+      shell: |
+        /usr/local/bin/openshift-baremetal-install --dir {{ dir }} --log-level debug create cluster
+      async: 3600
+      poll: 0
+      ignore_errors: yes
+      register: installer_result
+
+    - name: Wait for kubeconfig file
+      wait_for:
+        path: "{{ dir }}/auth/kubeconfig"
+        timeout: 90
+        msg: Timeout waiting for kubeconfig file
+
+    - name: Wait for Bootstrap Complete
+      shell: |
+        /usr/local/bin/openshift-baremetal-install --dir {{ dir }} --log-level debug wait-for bootstrap-complete
+      register: wait_for_bootstrap_result
+      until: wait_for_bootstrap_result is succeeded
+      retries: "{{ increase_bootstrap_timeout|int }}"
+      delay: 1
+
+    - name: Wait for Install Complete
+      shell: |
+        /usr/local/bin/openshift-baremetal-install --dir {{ dir }} --log-level debug wait-for install-complete
+      register: wait_for_install_result
+      until: wait_for_install_result is succeeded
+      retries: "{{ increase_install_timeout|int }}"
+      delay: 1
+  when: increase_bootstrap_timeout is defined or increase_install_timeout is defined
   tags: install


### PR DESCRIPTION
# Description

This change to the ansible deploy_ocp play allows for async'ing the initial installer to the background and then separately running wait-for commands for both bootstrap-complete and install-complete. This has two positive effects:

1. This extends (and allows for further extension of) the installer timeout, which is currently not adjustable at the installer itself and can be too short for larger bare metal deployments.
2. This provides more incremental feedback to the user regarding the status of the installation process.

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested an end-to-end IPI installation with the ansible automation, confirming that the async installer still allows the foreground wait-for commands and that the install completes successfully.

## Checklist

- [x] I have performed a self-review of my own code
- [x] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
