### PR TITLE
adding the clusterosimage feature

### DIFF
--- a/ansible-ipi-install/README.md
+++ b/ansible-ipi-install/README.md
@@ -279,11 +279,16 @@ dnsvip=""
 # Network Type (OpenShiftSDN or OVNKubernetes). Playbook defaults to OVNKubernetes.
 # Uncomment below for OpenShiftSDN
 #network_type="OpenShiftSDN"
-# (Optional) An URL to override the default operating system image for the bootstrap node.
+# (Optional) A URL to override the default operating system image for the bootstrap node.
 # The URL must contain a sha256 hash of the image.
 # See https://github.com/openshift/installer/blob/master/docs/user/metal/customization_ipi.md
 #   Example https://mirror.example.com/images/qemu.qcow2.gz?sha256=a07bd...
 #bootstraposimage=""
+# (Optional) A URL to override the default operating system image for the cluster nodes.
+# The URL must contain a sha256 hash of the image.
+# See https://github.com/openshift/installer/blob/master/docs/user/metal/customization_ipi.md
+# Example https://mirror.example.com/images/metal.qcow2.gz?sha256=3b5a8...
+#clusterosimage=""
 # A copy of your pullsecret from https://cloud.redhat.com/openshift/install/metal/user-provisioned
 pullsecret=""
 

--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -51,11 +51,16 @@ dnsvip=""
 # Network Type (OpenShiftSDN or OVNKubernetes). Playbook defaults to OVNKubernetes.
 # Uncomment below for OpenShiftSDN
 #network_type="OpenShiftSDN"
-# (Optional) An URL to override the default operating system image for the bootstrap node.
+# (Optional) A URL to override the default operating system image for the bootstrap node.
 # The URL must contain a sha256 hash of the image.
 # See https://github.com/openshift/installer/blob/master/docs/user/metal/customization_ipi.md
 #   Example https://mirror.example.com/images/qemu.qcow2.gz?sha256=a07bd...
 #bootstraposimage=""
+# (Optional) A URL to override the default operating system image for the cluster nodes.
+# The URL must contain a sha256 hash of the image.
+# See https://github.com/openshift/installer/blob/master/docs/user/metal/customization_ipi.md
+# Example https://mirror.example.com/images/metal.qcow2.gz?sha256=3b5a8...
+#clusterosimage=""
 # A copy of your pullsecret from https://cloud.redhat.com/openshift/install/metal/user-provisioned
 pullsecret=""
 

--- a/ansible-ipi-install/roles/node-prep/templates/install-config.j2
+++ b/ansible-ipi-install/roles/node-prep/templates/install-config.j2
@@ -24,6 +24,9 @@ platform:
 {% if bootstraposimage is defined and bootstraposimage|length %}
     bootstrapOSImage: {{ bootstraposimage }}
 {% endif %}
+{% if clusterosimage is defined and clusterosimage|length) %}
+    clusterOSImage: {{ clusterosimage }}
+{% endif %}
     hosts:
 {% for host in groups['masters'] %}
       - name: {{ hostvars[host]['name'] }}


### PR DESCRIPTION
# Description
adding the clusterosimage feature for 4.4+  into the install-config.yaml, also fixed grammar error in the text of boostraposimage explanation.

I don't have an environment to easily test this. I'm hoping @e-minguez and @abays can confirm

UPDATE: Confirmed clusterOSImage available in 4.3.1 GA so its not specific only to 4.4+

Fixes #174 

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing
The following tests are required:

* Confirm clusterOSImage to install-config.yaml is added when
** clusterosimage var is defined and not empty

* Confirm clusterOSImage is *not* added to install-config.yaml when
**  clusterosimage is defined but is empty string
** clusterosimage is *not* defined. 

## Checklist

- [ ] I have performed a self-review of my own code
- [x] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
