### PR TITLE
node-prep - make ipmi port configurable

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/110_power_off_cluster_servers.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/110_power_off_cluster_servers.yml
@@ -4,6 +4,7 @@
     name: "{{ hostvars[item]['ipmi_address'] }}"
     user: "{{ hostvars[item]['ipmi_user'] }}"
     password: "{{ hostvars[item]['ipmi_password'] }}"
+    port: "{{ hostvars[item]['ipmi_port'] | default(623) }}"
     state: off
   with_items:
     - "{{ groups['masters'] }}"


### PR DESCRIPTION
Signed-off-by: Johnny Bieren <jbieren@redhat.com>

# Description

Make ipmi port configurable in the task to power off nodes via ipmi_power in the node_prep role. Per https://docs.ansible.com/ansible/latest/modules/ipmi_power_module.html#parameter-port this should not change the existing functionality, but allows the option to overwrite the port, which is helpful in some of the VM setups where vbmc is set up on one address and each VM is on a different port.

I am not sure this helps anyone until the image caching gets in (aka when we can try finishing up and turning on the CI), so we can wait and double/triple check this, but it would help out once caching is in

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran Locally

**Test Configuration**:

- Versions: ansible 2.9.5
- Hardware:

## Checklist

- [X] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
