### PR TITLE
node-prep - make ipmi port configurable

### DIFF
--- a/ansible-ipi-install/README.md
+++ b/ansible-ipi-install/README.md
@@ -225,10 +225,10 @@ user input for the playbook to run.
 
 The hosts file also ensure to set up all your nodes that will be used to deploy
 IPI on baremetal. There are 3 groups: `masters`, `workers`, and `provisioner`. 
-The `masters` and `workers` group collects information about the host such as
-its name, role, user management (i.e. iDRAC) user, user management (i.e. iDRAC)
-password, ipmi_address to access the server and the provision mac address (NIC1)
-that resides on the provisioning network. 
+The `masters` and `workers` group collects information about the host such as 
+its name, role, user management (i.e. iDRAC) user, user management (i.e. iDRAC) 
+password, ipmi_address, ipmi_port to access the server and the provision mac 
+address (NIC1) that resides on the provisioning network.
 
 Below is a sample of the inventory/hosts file
 
@@ -306,15 +306,16 @@ pullsecret=""
 # Master nodes
 # The hardware_profile is used by the baremetal operator to match the hardware discovered on the host
 # See https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md#baremetalhost-status
+# ipmi_port is optional for each host. 623 is the common default used if omitted
 [masters]
-master-0 name=master-0 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.1 provision_mac=ec:f4:bb:da:0c:58 hardware_profile=default
-master-1 name=master-1 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.2 provision_mac=ec:f4:bb:da:32:88 hardware_profile=default
-master-2 name=master-2 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.3 provision_mac=ec:f4:bb:da:0d:98 hardware_profile=default
+master-0 name=master-0 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.1 ipmi_port=623 provision_mac=ec:f4:bb:da:0c:58 hardware_profile=default
+master-1 name=master-1 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.2 ipmi_port=623 provision_mac=ec:f4:bb:da:32:88 hardware_profile=default
+master-2 name=master-2 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.3 ipmi_port=623 provision_mac=ec:f4:bb:da:0d:98 hardware_profile=default
 
 # Worker nodes
 [workers]
-worker-0 name=worker-0 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.4 provision_mac=ec:f4:bb:da:0c:18 hardware_profile=unknown
-worker-1 name=worker-1 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.5 provision_mac=ec:f4:bb:da:32:28 hardware_profile=unknown
+worker-0 name=worker-0 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.4 ipmi_port=623 provision_mac=ec:f4:bb:da:0c:18 hardware_profile=unknown
+worker-1 name=worker-1 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.5 ipmi_port=623 provision_mac=ec:f4:bb:da:32:28 hardware_profile=unknown
 
 # Provision Host
 [provisioner]
@@ -324,10 +325,11 @@ provisioner.example.com
 NOTE: The `ipmi_address` can take a fully qualified name assuming it is 
 resolvable.
 
+NOTE: The `ipmi_port` examples above show how a user can specify a different `ipmi_port` for each host within their inventory file. If the `ipmi_port` variable is omitted from the inventory file, the default of 623 will be used.
+
 NOTE: A detailed description of the vars under the section 
 `Vars regarding install-config.yaml` 
-may be reviewed within  
-[Configure the install-config and metal3-config](https://github.com/openshift-kni/baremetal-deploy/blob/master/install-steps.md#configure-the-install-config-and-metal3-config)
+may be reviewed within  [Configure the install-config and metal3-config](https://github.com/openshift-kni/baremetal-deploy/blob/master/install-steps.md#configure-the-install-config-and-metal3-config)
 if unsure how to populate. 
 
 WARNING: If no `workers` are included, do not remove the workers group 

--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -72,15 +72,16 @@ pullsecret=""
 # Master nodes
 # The hardware_profile is used by the baremetal operator to match the hardware discovered on the host
 # See https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md#baremetalhost-status
+# ipmi_port is optional for each host. 623 is the common default used if omitted
 [masters]
-master-0 name=master-0 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.1 provision_mac=ec:f4:bb:da:0c:58 hardware_profile=default
-master-1 name=master-1 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.2 provision_mac=ec:f4:bb:da:32:88 hardware_profile=default
-master-2 name=master-2 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.3 provision_mac=ec:f4:bb:da:0d:98 hardware_profile=default
+master-0 name=master-0 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.1 ipmi_port=623 provision_mac=ec:f4:bb:da:0c:58 hardware_profile=default
+master-1 name=master-1 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.2 ipmi_port=623 provision_mac=ec:f4:bb:da:32:88 hardware_profile=default
+master-2 name=master-2 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.3 ipmi_port=623 provision_mac=ec:f4:bb:da:0d:98 hardware_profile=default
 
 # Worker nodes
 [workers]
-worker-0 name=worker-0 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.4 provision_mac=ec:f4:bb:da:0c:18 hardware_profile=unknown
-worker-1 name=worker-1 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.5 provision_mac=ec:f4:bb:da:32:28 hardware_profile=unknown
+worker-0 name=worker-0 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.4 ipmi_port=623 provision_mac=ec:f4:bb:da:0c:18 hardware_profile=unknown
+worker-1 name=worker-1 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.5 ipmi_port=623 provision_mac=ec:f4:bb:da:32:28 hardware_profile=unknown
 
 # Provision Host
 [provisioner]

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -32,7 +32,11 @@ platform:
       - name: {{ hostvars[host]['name'] }}
         role: {{ hostvars[host]['role'] }}
         bmc:
+{% if 'ipmi_port' in hostvars[host] %}
+          address: ipmi://{{ hostvars[host]['ipmi_address'] }}:{{ hostvars[host]['ipmi_port'] }}
+{% else %}
           address: ipmi://{{ hostvars[host]['ipmi_address'] }}
+{% endif %}
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}
         bootMACAddress: {{ hostvars[host]['provision_mac'] }}
@@ -46,7 +50,11 @@ platform:
       - name: {{ hostvars[host]['name'] }}
         role: {{ hostvars[host]['role'] }}
         bmc:
+{% if 'ipmi_port' in hostvars[host] %}
+          address: ipmi://{{ hostvars[host]['ipmi_address'] }}:{{ hostvars[host]['ipmi_port'] }}
+{% else %}
           address: ipmi://{{ hostvars[host]['ipmi_address'] }}
+{% endif %}
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}
         bootMACAddress: {{ hostvars[host]['provision_mac'] }}

--- a/ansible-ipi-install/roles/node-prep/tasks/100_power_off_cluster_servers.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/100_power_off_cluster_servers.yml
@@ -4,6 +4,7 @@
     name: "{{ hostvars[item]['ipmi_address'] }}"
     user: "{{ hostvars[item]['ipmi_user'] }}"
     password: "{{ hostvars[item]['ipmi_password'] }}"
+    port: "{{ hostvars[item]['ipmi_port'] | default(623) }}"
     state: off
   with_items:
     - "{{ groups['masters'] }}"


### PR DESCRIPTION
Signed-off-by: Johnny Bieren <jbieren@redhat.com>

# Description

Make ipmi port configurable in the task to power off nodes via ipmi_power in the node_prep role. Per https://docs.ansible.com/ansible/latest/modules/ipmi_power_module.html#parameter-port this should not change the existing functionality, but allows the option to overwrite the port, which is helpful in some of the VM setups where vbmc is set up on one address and each VM is on a different port.

I am not sure this helps anyone until the image caching gets in (aka when we can try finishing up and turning on the CI), so we can wait and double/triple check this, but it would help out once caching is in

I can do the install-config change inline if wanted

Fixes #191  

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran Locally

**Test Configuration**:

- Versions: ansible 2.9.5
- Hardware:

## Checklist

- [X] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
