### PR TITLE
Change packages to check if present not latest

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/30_req_packages.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/30_req_packages.yml
@@ -2,6 +2,6 @@
 - name: Install required packages
   package:
     name: "{{ item }}"
-    state: latest
+    state: present
   with_items: "{{ package_list }}"
   become: yes


### PR DESCRIPTION
# Description

Currently the 30_req_packages.yml attempts to get the latest packages. However, instead of checking whether the packages are latest, it makes more sense to ensure the packages are present instead. This fixes potential issues where customer may not be able to get some packages that require outside world access but if they install them, the playbook doesn't keep breaking attempting to retrieve the latest from the outside world even though the package was installed manually.

Fixes #185 

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
