### PR TITLE
Fixing Naming Inconsistencies

### DIFF
--- a/install-steps.md
+++ b/install-steps.md
@@ -58,11 +58,11 @@ document.
 | Ingress LB (apps) |  *.apps.\<cluster-name\>.\<domain\>  | \<ip\> |
 | Nameserver | ns1.\<cluster-name\>.\<domain\> | \<ip\> |
 | Provisioning node | provisioner.\<cluster-name\>.<domain\> | \<ip\> |
-| Master-0 | master-0.\<cluster-name\>.\<domain\> | \<ip\> |
-| Master-1 | master-1.\<cluster-name\>-.\<domain\> | \<ip\> |
-| Master-2 | master-2.\<cluster-name\>.\<domain\> | \<ip\> |
-| Worker-0 | worker-0.\<cluster-name\>.\<domain\> | \<ip\> |
-| Worker-1 | worker-1.\<cluster-name\>.\<domain\> | \<ip\> |
+| Master-0 | openshift-master-0.\<cluster-name\>.\<domain\> | \<ip\> |
+| Master-1 | openshift-master-1.\<cluster-name\>-.\<domain\> | \<ip\> |
+| Master-2 | openshift-master-2.\<cluster-name\>.\<domain\> | \<ip\> |
+| Worker-0 | openshift-worker-0.\<cluster-name\>.\<domain\> | \<ip\> |
+| Worker-1 | openshift-worker-1.\<cluster-name\>.\<domain\> | \<ip\> |
 
 ### DNS Server
 
@@ -190,11 +190,11 @@ environment specifics.
     *                       A       <wildcard-ingress-lb-ip>
     $ORIGIN openshift.example.com.
     provisioner             A       <NIC2-ip-of-provision>
-    openshift-master-0      A       <NIC2-ip-of-master-0>
-    openshift-master-1      A       <NIC2-ip-of-master-1>
-    openshift-master-2      A       <NIC2-ip-of-master-2>
-    openshift-worker-0      A       <NIC2-ip-of-worker-0>
-    openshift-worker-1      A       <NIC2-ip-of-worker-1>
+    openshift-master-0      A       <NIC2-ip-of-openshift-master-0>
+    openshift-master-1      A       <NIC2-ip-of-openshift-master-1>
+    openshift-master-2      A       <NIC2-ip-of-openshift-master-2>
+    openshift-worker-0      A       <NIC2-ip-of-openshift-worker-0>
+    openshift-worker-1      A       <NIC2-ip-of-openshift-worker-1>
     ~~~
 4. Increase the SERIAL value by 1
 5. Edit /var/named/dynamic/1.0.10.in-addr.arpa
@@ -273,33 +273,33 @@ DHCP reserverations using `dnsmasq` (Option 2).
          fixed-address <ip-address-of-NIC2>;
       }
     host openshift-master-0 {
-         option host-name "master-0";
+         option host-name "openshift-master-0";
          hardware ethernet <mac-address-of-NIC2>;
          option domain-search "openshift.example.com";
          fixed-address <ip-address-of-NIC2>;
       }
     
     host openshift-master-1 {
-         option host-name "master-1";
+         option host-name "openshift-master-1";
          hardware ethernet <mac-address-of-NIC2>;
          option domain-search "openshift.example.com";
          fixed-address <ip-address-of-NIC2>;
       }
     
     host openshift-master-2 {
-         option host-name "master-2";
+         option host-name "openshift-master-2";
          hardware ethernet <mac-address-of-NIC2>;
          option domain-search "openshift.example.com";
          fixed-address <ip-address-of-NIC2>;
       }
     host openshift-worker-0 {
-         option host-name "worker-0";
+         option host-name "openshift-worker-0";
          hardware ethernet <mac-address-of-NIC2>;
          option domain-search "openshift.example.com";
          fixed-address <ip-address-of-NIC2>;
       }
     host openshift-worker-1 {
-         option host-name "worker-1";
+         option host-name "openshift-worker-1";
          hardware ethernet <mac-address-of-NIC2>;
          option domain-search "openshift.example.com";
          fixed-address <ip-address-of-NIC2>;
@@ -357,11 +357,11 @@ the `baremetal` network.
 
    #Static IPs for Masters
    dhcp-host=<NIC2-mac-address>,provisioner.openshift.example.com,<ip-of-provisioner>
-   dhcp-host=<NIC2-mac-address>,openshift-master-0.openshift.example.com,<ip-of-master-0>
-   dhcp-host=<NIC2-mac-address>,openshift-master-1.openshift.example.com,<ip-of-master-1>
-   dhcp-host=<NIC2-mac-address>,openshift-master-2.openshift.example.com,<ip-of-master-2>
-   dhcp-host=<NIC2-mac-address>,openshift-worker-0.openshift.example.com,<ip-of-worker-0>
-   dhcp-host=<NIC2-mac-address>,openshift-worker-1.openshift.example.com,<ip-of-worker-1>
+   dhcp-host=<NIC2-mac-address>,openshift-master-0.openshift.example.com,<ip-of-openshift-master-0>
+   dhcp-host=<NIC2-mac-address>,openshift-master-1.openshift.example.com,<ip-of-openshift-master-1>
+   dhcp-host=<NIC2-mac-address>,openshift-master-2.openshift.example.com,<ip-of-openshift-master-2>
+   dhcp-host=<NIC2-mac-address>,openshift-worker-0.openshift.example.com,<ip-of-openshift-worker-0>
+   dhcp-host=<NIC2-mac-address>,openshift-worker-1.openshift.example.com,<ip-of-openshift-worker-1>
    ~~~
 6. Create the `resolv.conf.upstream` file in order to provide DNS fowarding to an existing DNS server for resolution to the outside world.
    ~~~sh
@@ -1023,10 +1023,10 @@ Once the prerequisites above have been set, the deploy process is as follows:
     ~~~sh
     oc get node
     NAME                                            STATUS   ROLES           AGE     VERSION
-    master-0                                        Ready    master          30h     v1.16.2
-    master-1                                        Ready    master          30h     v1.16.2
-    master-2                                        Ready    master          30h     v1.16.2
-    worker-0                                        Ready    worker          3m27s   v1.16.2
-    worker-1                                        Ready    worker          3m27s   v1.16.2
-    worker-2                                        Ready    worker          3m27s   v1.16.2
+    openshift-master-0.openshift.example.com        Ready    master          30h     v1.16.2
+    openshift-master-1.openshift.example.com        Ready    master          30h     v1.16.2
+    openshift-master-2.openshift.example.com        Ready    master          30h     v1.16.2
+    openshift-worker-0.openshift.example.com        Ready    worker          3m27s   v1.16.2
+    openshift-worker-1.openshift.example.com        Ready    worker          3m27s   v1.16.2
+    openshift-worker-2.openshift.example.com        Ready    worker          3m27s   v1.16.2
     ~~~


### PR DESCRIPTION
# Description

install-steps.md uses master-{0,1,2} and worker-{0,1} at one point, but then it uses openshift-master-{0,1,2} and openshift-worker-{0,1} later on. At a minimum it should be consistent.

Fixes #181 

## Type of change

Please select the appropiate options:

- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
