### PR TITLE
Get connection name for prov_nic

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
@@ -2,11 +2,17 @@
 - name: Setup Bridge Creation
   block:
     - name: Delete {{ prov_nic }} due to modify nmcli bug
-      nmcli: 
+      nmcli:
         conn_name: "{{ prov_nic }}"
         type: ethernet
         state: absent
-        
+
+    - name: Delete System {{ prov_nic }} due to modify nmcli bug
+      nmcli:
+        conn_name: "System {{ prov_nic }}"
+        type: ethernet
+        state: absent
+
     - name: Create Bridge labeled provisioning
       nmcli:
         conn_name: provisioning
@@ -16,7 +22,7 @@
         stp: off
         ip4: 172.22.0.1/24
         state: present
-    
+
     - name: Create Bridge slave on {{ prov_nic }}
       nmcli:
         conn_name: "{{ prov_nic }}"
@@ -27,7 +33,7 @@
         master: provisioning
         autoconnect: yes
         state: present
-        
+
     - name: Create Bridge labeled baremetal
       nmcli:
         conn_name: baremetal
@@ -36,7 +42,7 @@
         autoconnect: yes
         stp: off
         state: present
-    
+
     - name: Create Bridge slave on {{ pub_nic }}
       nmcli:
         conn_name: "{{ pub_nic }}"
@@ -46,16 +52,16 @@
         master: baremetal
         autoconnect: yes
         state: present
-    
+
     - name: Register the UUID of {{ pub_nic }}
       shell: |
-        nmcli c show | grep {{ pub_nic }} | awk '{ print $2 }' | grep -v {{ pub_nic }}
+        nmcli -f uuid,name,dev c show | awk '/{{ pub_nic }}/ { print $1 }'
       register: uuidoutput
-    
+
     - name: Set Fact for UUID
       set_fact:
         uuid: "{{ uuidoutput.stdout }}"
-    
+
     - name: Modify the Bridge slave file
       template:
         src: roles/node-prep/templates/pub_nic.j2
@@ -63,7 +69,7 @@
         owner: root
         group: root
         mode: u=rw,g=r,o=r
-    
+
     - name: Reload baremetal bridge and slave interfaces
       shell: |
         /usr/bin/nmcli con reload {{ item }}; /usr/bin/nmcli con up {{ item }}
@@ -78,4 +84,3 @@
     gather_subset:
       - network
   tags: network
-


### PR DESCRIPTION
# Description

On RHEL8 there is no connection with name matching value of `prov_nic` variable.
To delete connection that uses `prov_nic` interface obtain its name by filtering output of `nmcli -f device,uuid con` command

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Run the playbook

**Test Configuration**:

- Versions: 4.3.0-0.nightly-2020-03-04-165955
- Hardware: vms

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
