### PR TITLE
regathering network facts

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
@@ -72,3 +72,10 @@
         - "{{ pub_nic }}"
   become: yes
   tags: network
+
+- name: Regather Network Facts
+  setup:
+    gather_subset:
+      - network
+  tags: network
+


### PR DESCRIPTION
# Description

On a fresh install if you enable the cache_enabled true, our playbook uses ansible facts of our eth devices. However, the ansible_provisiong fact is yet to be defined at the beginning of the play so we must regather our network facts in order to ensure the variable is defined

Fixes #211 

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
