### PR TITLE
Added cache instructions

### DIFF
--- a/install-steps.md
+++ b/install-steps.md
@@ -576,7 +576,47 @@ sudo cp ./oc /usr/local/bin/oc
 oc adm release extract --registry-config "${pullsecret_file}" --command=$cmd --to "${extract_dir}" ${RELEASE_IMAGE}
 ~~~
 
+### Create RHCOS images cache (Optional)
 
+The installer needs to download two images, the RHCOS image used by the bootstrap VM and the RHCOS image used by the installer to provision the different nodes. Image caching is specially useful when running the installer on a network with limited bandwidth.
+
+When running the installer on a network with limited bandwidth if the RHCOS images download takes more than 15-20 minutes, the installer will timeout, having images cached on a webserver will help in such scenarios.
+
+The following steps install a container that servers up the required images:
+
+~~~sh
+# Install podman
+sudo dnf install -y podman
+# Open firewall port 8080 to be used for RHCOS Image caching
+sudo firewall-cmd --add-port=8080/tcp --zone=public --permanent
+# Create a directory to store the bootstraposimage and clusterosimage
+mkdir /home/kni/rhcos_image_cache
+# Set the appropriate SELinux context for the newly created directory
+sudo semanage fcontext -a -t httpd_sys_content_t "/home/kni/rhcos_image_cache(/.*)?"
+sudo restorecon -Rv rhcos_image_cache/
+# Get the commit id from the installer it will be used to determine which images do we need to download
+export COMMIT_ID=$(/home/kni/openshift-baremetal-install version | grep '^built from commit' | awk '{print $4}')
+# Get the uri for the RHCOS image that will be deployed on the nodes
+export RHCOS_OPENSTACK_URI=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq .images.openstack.path | sed 's/"//g')
+# Get the uri for the RHCOS image that will be deployed on the bootstrap vm
+export RHCOS_QEMU_URI=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq .images.qemu.path | sed 's/"//g')
+# Get the path where the images are published
+export RHCOS_PATH=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json | jq .baseURI | sed 's/"//g')
+# Get the SHA hash for the RHCOS image that will be deployed on the bootstrap vm
+export RHCOS_QEMU_SHA_UNCOMPRESSED=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq -r '.images.qemu["uncompressed-sha256"]')
+# Get the SHA hash for the RHCOS image that will be deployed on the nodes
+export RHCOS_OPENSTACK_SHA_COMPRESSED=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq -r '.images.openstack.sha256')
+# Download the images and place them in the  /home/kni/rhcos_image_cache directory
+curl -L ${RHCOS_PATH}${RHCOS_QEMU_URI} -o /home/kni/rhcos_image_cache
+curl -L ${RHCOS_PATH}${RHCOS_OPENSTACK_URI} -o /home/kni/rhcos_image_cache
+# Confirm SELinux type is of httpd_sys_content_t for the newly created files.
+ls -Z /home/kni/rhcos_image_cache
+# Create pod
+podman run -d --name rhcos_image_cache \
+-v /home/kni/rhcos_image_cache:/var/www/html \
+-p 8080:8080/tcp \
+registry.centos.org/centos/httpd-24-centos7:latest
+~~~
 
 ## Configure the install-config and metal3-config
 
@@ -599,6 +639,9 @@ oc adm release extract --registry-config "${pullsecret_file}" --command=$cmd --t
         baremetal: {}
     platform:
       baremetal:
+        # If you are using cached images you need to configure the following properties (bootstrapOSImage and clusterOSImage) so the installer gets the images from the cache https://github.com/openshift-kni/baremetal-deploy/blob/master/install-steps.md#create-rhcos-images-cache-optional
+        # bootstrapOSImage: http://172.22.0.1:8080/$RHCOS_QEMU_URI?sha256=$RHCOS_QEMU_SHA_UNCOMPRESSED
+        # clusterOSImage: http://172.22.0.1:8080/$RHCOS_OPENSTACK_URI?sha256=$RHCOS_OPENSTACK_SHA_COMPRESSED
         apiVIP: <api-ip>
         ingressVIP: <wildcard-ip>
         dnsVIP: <dns-ip>


### PR DESCRIPTION
# Description

Added instructions for creating a cache for RHCOS images. This is useful when running the installer on a network with limited bandwidth. Under such circumstances is pretty common for the installer to timeout when not using RHCOS cached images.

This is inspired on @karmab [kcli](https://github.com/karmab/kcli) cache script[1]

[1] https://github.com/karmab/kcli-plans/blob/master/openshift4/baremetal/cache.sh

## Type of change

Please select the appropiate options:

- [ ] This change requires a documentation update

## Testing

Doc changed.

**Test Configuration**:

Latest openshift baremetal installer.
Dell servers.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
