### PR TITLE
Fix and simplify cache downloads

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
+++ b/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
@@ -16,17 +16,8 @@
 # rhcos_json fact already set in 23_rhcos_image_paths.yaml
 - name: Set facts for RHCOS_QEMU_SHA256 and RHCOS_SHA256
   set_fact:
-    rhcos_qemu_sha256: '{{ rhcos_json.json | json_query(''images.qemu."uncompressed-sha256"'') }}'
+    rhcos_qemu_sha256: "{{ rhcos_json.json | json_query('images.qemu.sha256') }}"
     rhcos_sha256: "{{ rhcos_json.json | json_query('images.openstack.sha256') }}"
-  tags: cache
-
-- name: Check if {{ rhcos_qemu_uri }} is already in cache
-  stat: 
-    path: "{{ provision_cache_store }}{{ rhcos_qemu_uri }}"
-    checksum_algorithm: sha256
-    get_checksum: yes
-  register: rhcos_qemu_stat
-  when: bootstraposimage is not defined or bootstraposimage|length < 1
   tags: cache
 
 - name: Download {{ rhcos_qemu_uri }} for cache
@@ -37,17 +28,9 @@
     group: "{{ ansible_user }}"
     mode: '0644'
     setype: httpd_sys_content_t
+    checksum: "sha256:{{ rhcos_qemu_sha256 }}"
     timeout: 3600
-  when: (bootstraposimage is not defined or bootstraposimage|length < 1) and (rhcos_qemu_stat.stat.exists == false or rhcos_qemu_stat.stat.checksum != rhcos_qemu_sha256)
-  tags: cache
-
-- name: Check if {{ rhcos_uri }} is already in cache
-  stat: 
-    path: "{{ provision_cache_store }}{{ rhcos_uri }}"
-    checksum_algorithm: sha256
-    get_checksum: yes
-  register: rhcos_stat
-  when: clusterosimage is not defined or clusterosimage|length < 1
+  when: (bootstraposimage is not defined or bootstraposimage|length < 1)
   tags: cache
 
 - name: Download {{ rhcos_uri }} for cache
@@ -58,8 +41,9 @@
     group: "{{ ansible_user }}"
     mode: '0644'
     setype: httpd_sys_content_t
+    checksum: "sha256:{{ rhcos_sha256 }}"
     timeout: 3600
-  when: (clusterosimage is not defined or clusterosimage|length < 1) and (rhcos_stat.stat.exists == false or rhcos_stat.stat.checksum != rhcos_sha256)
+  when: (clusterosimage is not defined or clusterosimage|length < 1)
   tags: cache
 
 - name: Set bootstrap image URL override if not provided by the user


### PR DESCRIPTION
# Description

We were using the wrong sha256 checksum for the RHCOS qemu (bootstrap) image in our cache setup logic.  This fixes that and uses the Ansible `get_url`'s built-in checksum option to make the sha256 comparisons.

Fixes https://github.com/openshift-kni/baremetal-deploy/issues/215

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Test against an environment with RHCOS images already downloaded to the cache for the particular version of OCP in which you are interested.  Run the playbook and make sure that the "Download" tasks for the qemu image and the openstack image and not re-downloaded.

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
