### PR TITLE
removing requirement of raid-1

### DIFF
--- a/install-steps.md
+++ b/install-steps.md
@@ -5,7 +5,7 @@ This write-up will guide you through the process of deploying a Baremetal IPI in
 
 * 6 Physical servers (1 provision node, 3 master and 2 worker nodes)
 * Each server needs 2 NICs pre-configured. NIC1 for the private network and NIC2 for the external network. NIC interface names need to be identical. See [issue](https://github.com/openshift/installer/issues/2762)
-* Each server should have a RAID-1 configured and initialized
+* It is recommended each server have a RAID-1 configured and initialized (though not enforced)
 * Each server must have IPMI configured
 * Each server must have DHCP setup for external NICs
 * Each server must have DNS setup for the API, wildcard applications


### PR DESCRIPTION
# Description

Per request, removing the verbiage that says RAID-1 is required. 

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
