### PR TITLE
UUID is empty due to incorrect nmcli command

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
@@ -55,7 +55,7 @@
 
     - name: Register the UUID of {{ pub_nic }}
       shell: |
-        nmcli -f uuid,name,dev c show | awk '/{{ pub_nic }}/ { print $1 }'
+        nmcli -f uuid,name,device c show | awk '/{{ pub_nic }}/ { print $1 }'
       register: uuidoutput
 
     - name: Set Fact for UUID


### PR DESCRIPTION
# Description

The command 
``` 
nmcli -f uuid,name,dev c show | awk '/{{ pub_nic }}/ { print $1 }'
```
is not providing a UUID because its needs the word device

command must be:
```
 nmcli -f uuid,name,device c show | awk '/{{ pub_nic }}/ { print $1 }'
```

Fixes #219 

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
