### PR TITLE
Don't specify full path to templates

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
@@ -64,7 +64,7 @@
 
     - name: Modify the Bridge slave file
       template:
-        src: roles/node-prep/templates/pub_nic.j2
+        src: pub_nic.j2
         dest: "/etc/sysconfig/network-scripts/ifcfg-{{ pub_nic }}"
         owner: root
         group: root

--- a/ansible-ipi-install/roles/node-prep/tasks/80_libvirt_pool.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/80_libvirt_pool.yml
@@ -5,7 +5,7 @@
       virt_pool:
         command: define
         name: default
-        xml: '{{ lookup("template", "roles/node-prep/templates/dir.xml.j2") }}'
+        xml: '{{ lookup("template", "dir.xml.j2") }}'
     
     - name: Start Storage Pool for default
       virt_pool:


### PR DESCRIPTION
ansible will find the templates in the roles templates
directory automatically.  By putting the full path it
prevents the roles from working from other working directories.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #231 

## Type of change

Please select the appropiate options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran via dci workflow

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [X] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
