### PR TITLE
removing full path of templates

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/80_libvirt_pool.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/80_libvirt_pool.yml
@@ -5,7 +5,7 @@
       virt_pool:
         command: define
         name: default
-        xml: '{{ lookup("template", "roles/node-prep/templates/dir.xml.j2") }}'
+        xml: '{{ lookup("template", "dir.xml.j2") }}'
     
     - name: Start Storage Pool for default
       virt_pool:


### PR DESCRIPTION
# Description

ansible will find the templates in the roles templates
directory automatically. By putting the full path it
prevents the roles from working from other working directories.

UPDATE: I just created this PR so that @p3ck would not need to rebase since we removed one of the changes from the 40_bridge file. 

Fixes #231 #230 

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
