### PR TITLE
removing 5000 as default fw rule

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/70_enabled_fw_services.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/70_enabled_fw_services.yml
@@ -8,17 +8,6 @@
         state: enabled
       become: yes
 
-    - name: Open port 5000/tcp, zone libvirt and public, for firewalld
-      firewalld:
-        port: 5000/tcp
-        permanent: yes
-        state: enabled
-        zone: "{{ item }}"
-      become: yes
-      with_items:
-      - libvirt
-      - public
-
     - name: Open port 8080/tcp, zone public, for cache for firewalld
       firewalld:
         port: 8080/tcp
@@ -37,14 +26,6 @@
         chain: INPUT
         protocol: tcp
         destination_port: "80"
-        jump: ACCEPT
-      become: yes
-
-    - name: Open port 5000/tcp for iptables
-      iptables:
-        chain: INPUT
-        protocol: tcp
-        destination_port: "5000"
         jump: ACCEPT
       become: yes
 


### PR DESCRIPTION
# Description

Removing opening the FW port 5000 by default on provisioning host. Only required when doing disconnected installs.

Fixes #238 

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
