### PR TITLE
[doc] removing requirement of port 5000

### DIFF
--- a/install-steps.md
+++ b/install-steps.md
@@ -437,12 +437,10 @@ The following steps need to be performed in order to prepare the environment.
    ~~~sh
    usermod --append --groups libvirt <user> 
    ~~~
-8. Restart `firewalld`, enable the `http` service, enable port 5000.
+8. Restart `firewalld` and enable the `http` service
    ~~~sh
    systemctl restart firewalld
    firewall-cmd --zone=public --add-service=http --permanent
-   firewall-cmd --add-port=5000/tcp --zone=libvirt  --permanent
-   firewall-cmd --add-port=5000/tcp --zone=public   --permanent
    firewall-cmd --reload
    ~~~
 9. Start and enable the `libvirtd` service


### PR DESCRIPTION
# Description

Removing the requirement of opening port 5000. Port 5000 only needed for disconnected installs. 

Fixes #239 

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
