### PR TITLE
Only set extcidrnet if not provided

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
@@ -128,7 +128,7 @@
     extcidrnet: "{{ ip | ipaddr('network') }}/{{ ip | ipaddr('prefix') }}"
   vars:
     ip: "{{ ansible_default_ipv4.address }}/{{ansible_default_ipv4.netmask }}"
-  when: not ipv6_enabled|bool
+  when: (extcidrnet is not defined or extcidrnet|length < 1) and not ipv6_enabled|bool
   tags: network
 
 - name: Set External Subnet with IPv6
@@ -136,7 +136,7 @@
     extcidrnet: "{{ ip | ipaddr('network') }}/{{ ip | ipaddr('prefix') }}"
   vars:
     ip: "{{ ansible_default_ipv6.address }}/64"
-  when: ipv6_enabled|bool
+  when: (extcidrnet is not defined or extcidrnet|length < 1) and ipv6_enabled|bool
   tags: network
 
 - debug:


### PR DESCRIPTION
# Description

We should only set the `extcidrnet` variable if the user hasn't provided it in the host variables already.  Otherwise we override what they have explicitly set.

Fixes https://github.com/openshift-kni/baremetal-deploy/issues/242

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

1. Set `extcidrnet` in your host vars.  Execute the playbook and wait until it generates `install-config.yaml`.  Then, examine either `install-config.yaml` or `install-config.yaml.bkup` and make sure that `networking.machineCIDR` is set to the value provided for `extcidrnet`.

2. Do NOT set `extcidrnet` in your host vars.  Execute the playbook and wait until it generates `install-config.yaml`.  Then, examine either `install-config.yaml` or `install-config.yaml.bkup` and make sure that `networking.machineCIDR` is set to the CIDR of the public network on the provisioning host.

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
