### PR TITLE
removing ipaddr filter when using hostnames

### DIFF
--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -40,9 +40,9 @@ platform:
         role: {{ hostvars[host]['role'] }}
         bmc:
 {% if 'ipmi_port' in hostvars[host] %}
-          address: ipmi://{{ hostvars[host]['ipmi_address']|ipaddr|ipwrap }}:{{ hostvars[host]['ipmi_port'] }}
+          address: ipmi://{{ hostvars[host]['ipmi_address']|ipwrap }}:{{ hostvars[host]['ipmi_port'] }}
 {% else %}
-          address: ipmi://{{ hostvars[host]['ipmi_address']|ipaddr|ipwrap }}
+          address: ipmi://{{ hostvars[host]['ipmi_address']|ipwrap }}
 {% endif %}
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}
@@ -58,9 +58,9 @@ platform:
         role: {{ hostvars[host]['role'] }}
         bmc:
 {% if 'ipmi_port' in hostvars[host] %}
-          address: ipmi://{{ hostvars[host]['ipmi_address']|ipaddr|ipwrap }}:{{ hostvars[host]['ipmi_port'] }}
+          address: ipmi://{{ hostvars[host]['ipmi_address']|ipwrap }}:{{ hostvars[host]['ipmi_port'] }}
 {% else %}
-          address: ipmi://{{ hostvars[host]['ipmi_address']|ipaddr|ipwrap }}
+          address: ipmi://{{ hostvars[host]['ipmi_address']|ipwrap }}
 {% endif %}
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}

--- a/ansible-ipi-install/roles/installer/templates/metal3-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/metal3-config.j2
@@ -5,12 +5,12 @@ metadata:
   namespace: openshift-machine-api
 data:
   cache_url: ''
-  deploy_kernel_url: http://{{ prov_ip|ipaddr|ipwrap }}:6180/images/ironic-python-agent.kernel
-  deploy_ramdisk_url: http://{{ prov_ip|ipaddr|ipwrap }}:6180/images/ironic-python-agent.initramfs
+  deploy_kernel_url: http://{{ prov_ip|ipwrap }}:6180/images/ironic-python-agent.kernel
+  deploy_ramdisk_url: http://{{ prov_ip|ipwrap }}:6180/images/ironic-python-agent.initramfs
   dhcp_range: 172.22.0.10,172.22.0.100
   http_port: "6180"
-  ironic_endpoint: http://{{ prov_ip|ipaddr|ipwrap }}:6385/v1/
-  ironic_inspector_endpoint: http://{{ prov_ip|ipaddr|ipwrap }}:5050/v1/
+  ironic_endpoint: http://{{ prov_ip|ipwrap }}:6385/v1/
+  ironic_inspector_endpoint: http://{{ prov_ip|ipwrap }}:5050/v1/
   provisioning_interface: {{ prov_nic }}
   provisioning_ip: {{ prov_ip }}/24
 {% if clusterosimage is defined and clusterosimage|length %}


### PR DESCRIPTION
# Description

The current logic uses
```
"{{ hostvars['master-0']['ipmi_address'] | ipaddr | ipwrap }}"
```
If the ipmi_address is a hostname this will resolve to False. What is required is to remove the ipaddr filter so it doesn't filter out hostnames
```
"{{ hostvars['master-0']['ipmi_address'] | ipwrap }}"
```

Fixes #245 

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
