### PR TITLE
removing pub nic j2 as no longer in use

### DIFF
--- a/ansible-ipi-install/README.md
+++ b/ansible-ipi-install/README.md
@@ -155,7 +155,6 @@ The tree structure is shown below:
         │   └── main.yml
         ├── templates
         │   ├── dir.xml.j2
-        │   └── pub_nic.j2
         ├── tests
         │   ├── inventory
         │   └── test.yml

--- a/ansible-ipi-install/roles/node-prep/templates/pub_nic.j2
+++ b/ansible-ipi-install/roles/node-prep/templates/pub_nic.j2
@@ -1,6 +1,0 @@
-TYPE=Ethernet
-NAME={{ pub_nic }}
-DEVICE={{ pub_nic }}
-ONBOOT=yes
-BRIDGE=baremetal
-UUID={{ uuid }}


### PR DESCRIPTION
# Description

Removing the `pub_nic.j2` file as its no longer used by the `40_bridge.yml` script

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
