### PR TITLE
Adding proxy capability to the playbook and adding proxy to OpenShift

### DIFF
--- a/ansible-ipi-install/README.md
+++ b/ansible-ipi-install/README.md
@@ -28,6 +28,7 @@ _**Table of contents**_
 - [Appendix A. Using Ansible Tags with the `playbook.yml`](#appendix-a-using-ansible-tags-with-the-playbookyml)
   - [How to use the Ansible tags](#how-to-use-the-ansible-tags)
   - [Skipping particular tasks using Ansible tags](#skipping-particular-tasks-using-ansible-tags)
+- [Appendix B - Using a proxy with your Ansible playbook](#appendix-b-using-a-proxy-with-your-ansible-playbook)
 
 <!-- /TOC -->
 
@@ -748,4 +749,28 @@ Example 1
 
 ```sh
 ansible-playbook -i inventory/hosts playbook.yml --skip-tags "network,packages"
+```
+
+# Appendix B. Using a proxy with your Ansible playbook
+
+When running behind a proxy, it is important to properly set the environment
+to handle such scenario such that you can run the Ansible playbook. In order
+to use a proxy for the ansible playbook set the appropriate variables within
+your `inventory/hosts` file. These values will also be included within your
+generated `install-config.yaml` file. 
+
+```sh
+# (Optional) Provide HTTP proxy settings
+#http_proxy=http://USERNAME:PASSWORD@proxy.example.com:8080
+
+# (Optional) Provide HTTPS proxy settings
+#https_proxy=https://USERNAME:PASSWORD@proxy.example.com:8080
+
+# (Optional) comma-separated list of hosts, IP Addresses, or IP ranges in CIDR format
+# excluded from proxying
+# NOTE: OpenShift does not accept '*' as a wildcard attached to a domain suffix
+# i.e. *.example.com
+# Use '.' as the wildcard for a domain suffix as shown in the example below. 
+# i.e. .example.com
+#no_proxy_list="172.22.0.0/24,.example.com"
 ```

--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -40,6 +40,21 @@ prov_ip=172.22.0.3
 # (Optional) A list of clock servers to be used in chrony by the masters and workers
 #clock_servers=["pool.ntp.org","clock.redhat.com"]
 
+# (Optional) Provide HTTP proxy settings
+#http_proxy=http://USERNAME:PASSWORD@proxy.example.com:8080
+
+# (Optional) Provide HTTPS proxy settings
+#https_proxy=https://USERNAME:PASSWORD@proxy.example.com:8080
+
+# (Optional) comma-separated list of hosts, IP Addresses, or IP ranges in CIDR format
+# excluded from proxying
+# NOTE: OpenShift does not accept '*' as a wildcard attached to a domain suffix
+# i.e. *.example.com
+# Use '.' as the wildcard for a domain suffix as shown in the example below. 
+# i.e. .example.com
+#no_proxy_list="172.22.0.0/24,.example.com"
+
+
 ######################################
 # Vars regarding install-config.yaml #
 ######################################

--- a/ansible-ipi-install/playbook.yml
+++ b/ansible-ipi-install/playbook.yml
@@ -5,4 +5,7 @@
   - node-prep
   - installer
 
-
+  environment:
+    http_proxy: "{{ http_proxy }}"
+    https_proxy: "{{ https_proxy }}"
+    no_proxy: "{{ no_proxy_list }}"

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -1,5 +1,11 @@
 apiVersion: v1
 baseDomain: {{ domain }}
+{%if (http_proxy|length or https_proxy|length) %}
+proxy:
+  httpProxy: {{ http_proxy }}
+  httpsProxy: {{ https_proxy }}
+  noProxy: {{ (no_proxy_list|length) | ternary(no_proxy_list + ',' + provisioning_subnet, provisioning_subnet) }}
+{% endif %}
 metadata:
   name: {{ cluster }}
 networking:

--- a/ansible-ipi-install/roles/node-prep/defaults/main.yml
+++ b/ansible-ipi-install/roles/node-prep/defaults/main.yml
@@ -6,3 +6,6 @@ release_url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-prev
 network_type: "OVNKubernetes"
 firewall: "firewalld"
 ipv6_enabled: false
+no_proxy_list: ""
+http_proxy: ""
+https_proxy: ""

--- a/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
@@ -139,7 +139,29 @@
   when: (extcidrnet is not defined or extcidrnet|length < 1) and ipv6_enabled|bool
   tags: network
 
+- name: set provisioning subnet with IPV4
+  set_fact:
+    provisioning_subnet: "{{ ip | ipaddr('network') }}/{{ ip | ipaddr('prefix') }}"
+  vars:
+    ip: "{{ ansible_facts.provisioning.ipv4.address }}/{{ansible_facts.provisioning.ipv4.netmask }}"
+  when: not ipv6_enabled|bool or ((release_version[0]|int == 4) and (release_version[2]|int == 3))
+  tags: network
+
+- name: set provisioning subnet with IPV6
+  set_fact:
+    provisioning_subnet: "{{ ip | ipaddr('network') }}/{{ ip | ipaddr('prefix') }}"
+  vars:
+    ip: "{{ ansible_facts.provisioning.ipv6[0].address }}/{{ansible_facts.provisioning.ipv6[0].prefix }}"
+  when: (ipv6_enabled|bool and ((release_version[0]|int == 4) and (release_version[2]|int > 3))) or
+        (ipv6_enabled|bool and (release_version[0]|int > 4))
+  tags: network
+
 - debug:
     msg: "external subnet {{ extcidrnet }}"
+    verbosity: 2
+  tags: network
+
+- debug:
+    msg: "provisioning subnet {{ provisioning_subnet }}"
     verbosity: 2
   tags: network


### PR DESCRIPTION
# Description

Adding the ability to use a proxy when running the Ansible playbook and include the proxy settings for the OpenShift cluster 

Fixes: #189 

## Type of change

Please select the appropiate options:

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

Tested the different combinations of using/not using the different variables http_proxy, https_proxy, no_proxy with and without an external proxy. 

**Test Configuration**:

- Versions: 4.3.8

## Checklist

- [x] I have performed a self-review of my own code
- [x] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
