### PR TITLE
Fix incorrect variable name

### DIFF
--- a/ansible-ipi-install/roles/node-prep/library/nmcli.py
+++ b/ansible-ipi-install/roles/node-prep/library/nmcli.py
@@ -115,7 +115,7 @@ options:
             - This is only used with bond and is the primary interface name (for "active-backup" mode), this is the usually the 'ifname'
     id:
         descrption:
-            - This will allow to change the bridge slave device name (connection.id) to our preferred name. 
+            - This will allow to change the bridge slave device name (connection.id) to our preferred name.
         version: 2.9
     miimon:
         description:
@@ -1010,7 +1010,7 @@ class Nmcli(object):
             'ipv6.addresses': self.ip6,
             'ipv6.method': self.ip6_method,
             'ipv6.dhcp-duid': self.ip6_dhcp_duid,
-            'ipv4.gateway': self.gw6,
+            'ipv6.gateway': self.gw6,
             'autoconnect': self.bool_to_string(self.autoconnect),
             'bridge.ageing-time': self.ageingtime,
             'bridge.forward-delay': self.forwarddelay,


### PR DESCRIPTION
# Description

Variable for ipv4 was being redefined from ipv6 gateway which looks like a typo (variable for ipv4 is defined some lines above).

Change name to be variable for ipv6 vars


Fixes # (issue)

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [x] I have performed a self-review of my own code
- [x] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.



Closes #256