### PR TITLE
Use tagged version of filetranspiler

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/35_customize_filesystem.yml
+++ b/ansible-ipi-install/roles/installer/tasks/35_customize_filesystem.yml
@@ -20,7 +20,7 @@
 
   - name: Get Filetranspiler
     get_url:
-      url: https://raw.githubusercontent.com/ashcrow/filetranspiler/master/filetranspile
+      url: https://raw.githubusercontent.com/ashcrow/filetranspiler/1.1.1/filetranspile
       dest: "{{ tempdir }}/filetranspile.py"
       mode: '0755'
 


### PR DESCRIPTION
In latest master filetranspiler, we see the following error when running
filetranspile.py: import magic", "ModuleNotFoundError: No module named 'magic due to the new reuirement introduced on python package file-magic.

# Description

When running the task at https://github.com/openshift-kni/baremetal-deploy/blob/master/ansible-ipi-install/roles/installer/tasks/35_customize_filesystem.yml#L45, it fails as following https://gist.githubusercontent.com/smalleni/f347622a1940c144cc5b92f20593bdb6/raw/588045dc8046e37c820f57a86034160a130fabb6/gistfile1.txt


Fixes # (issue)
https://github.com/openshift-kni/baremetal-deploy/issues/257
## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Getting the tagged version means file-magic is no longer needed.

- Versions: Trying to install OC 4.3.5
- Hardware: RHEL 8.1 admin host

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
