### PR TITLE
Fix metal3 URL when not using cache

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/23_rhcos_image_paths.yml
+++ b/ansible-ipi-install/roles/installer/tasks/23_rhcos_image_paths.yml
@@ -17,5 +17,6 @@
     rhcos_qemu_uri: "{{ rhcos_json.json | json_query('images.qemu.path') }}"
     rhcos_uri: "{{ rhcos_json.json | json_query('images.openstack.path') }}"
     rhcos_path: "{{ rhcos_json.json | json_query('baseURI') }}"
+    rhcos_sha256: "{{ rhcos_json.json | json_query('images.openstack.sha256') }}"
   tags: rhcospath
   

--- a/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
+++ b/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
@@ -18,7 +18,6 @@
   set_fact:
     rhcos_qemu_sha256: "{{ rhcos_json.json | json_query('images.qemu.sha256') }}"
     rhcos_qemu_sha256_unzipped: '{{ rhcos_json.json | json_query(''images.qemu."uncompressed-sha256"'') }}'
-    rhcos_sha256: "{{ rhcos_json.json | json_query('images.openstack.sha256') }}"
   tags: cache
 
 - name: Download {{ rhcos_qemu_uri }} for cache

--- a/ansible-ipi-install/roles/installer/templates/metal3-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/metal3-config.j2
@@ -16,6 +16,6 @@ data:
 {% if clusterosimage is defined and clusterosimage|length %}
   rhcos_image_url: {{ clusterosimage }}
 {% else %}
-  rhcos_image_url: {{ rhcos_path }}{{ rhcos_uri }}
+  rhcos_image_url: {{ rhcos_path }}{{ rhcos_uri }}?sha256={{ rhcos_sha256 }}
 {% endif %}
 


### PR DESCRIPTION
# Description

The RHCOS URL in the metal3-config if not using caching does not include the sha256. This is still being confirmed if needed. 

Fixes #263 

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
