### PR TITLE
check to see if using yum package directly fixes not installing certain packages

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/30_req_packages.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/30_req_packages.yml
@@ -7,9 +7,9 @@
     when: cache_enabled == True
 
   - name: Install required packages
-    package:
-      name: "{{ item }}"
+    yum:
+      name: "{{ package_list }}"
       state: present
-    with_items: "{{ package_list }}"
+      update_cache: true
     become: yes
   tags: packages


### PR DESCRIPTION
# Description

We are experiencing some odd behavior where some packages are giving false positive from the package module. Attempting to use the yum module instead to force update_cache to true. The update_cache: true parameter when installing or updating packages, which forces yum to check if the package cache is out of date and it update it if needed.

Fixes #260 

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
