### PR TITLE
fixing isolating regathering network facts via a tag

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
@@ -121,7 +121,8 @@
   setup:
     gather_subset:
       - network
-  tags: network
+  tags: 
+  - network_facts
 
 - name: Set External Subnet with IPv4
   set_fact:
@@ -129,7 +130,8 @@
   vars:
     ip: "{{ ansible_default_ipv4.address }}/{{ansible_default_ipv4.netmask }}"
   when: (extcidrnet is not defined or extcidrnet|length < 1) and not ipv6_enabled|bool
-  tags: network
+  tags: 
+  - network_facts
 
 - name: Set External Subnet with IPv6
   set_fact:
@@ -137,7 +139,8 @@
   vars:
     ip: "{{ ansible_default_ipv6.address }}/64"
   when: (extcidrnet is not defined or extcidrnet|length < 1) and ipv6_enabled|bool
-  tags: network
+  tags: 
+  - network_facts
 
 - name: set provisioning subnet with IPV4
   set_fact:
@@ -145,7 +148,8 @@
   vars:
     ip: "{{ ansible_facts.provisioning.ipv4.address }}/{{ansible_facts.provisioning.ipv4.netmask }}"
   when: not ipv6_enabled|bool or ((release_version[0]|int == 4) and (release_version[2]|int == 3))
-  tags: network
+  tags: 
+  - network_facts
 
 - name: set provisioning subnet with IPV6
   set_fact:
@@ -154,14 +158,17 @@
     ip: "{{ ansible_facts.provisioning.ipv6[0].address }}/{{ansible_facts.provisioning.ipv6[0].prefix }}"
   when: (ipv6_enabled|bool and ((release_version[0]|int == 4) and (release_version[2]|int > 3))) or
         (ipv6_enabled|bool and (release_version[0]|int > 4))
-  tags: network
+  tags: 
+  - network_facts
 
 - debug:
     msg: "external subnet {{ extcidrnet }}"
     verbosity: 2
-  tags: network
+  tags: 
+  - network_facts
 
 - debug:
     msg: "provisioning subnet {{ provisioning_subnet }}"
     verbosity: 2
-  tags: network
+  tags: 
+  - network_facts

--- a/ansible-ipi-install/roles/node-prep/tasks/main.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/main.yml
@@ -13,7 +13,9 @@
 - include_tasks: 30_req_packages.yml 
   tags: packages
 - include_tasks: 40_bridge.yml
-  tags: network
+  tags: 
+  - network
+  - network_facts
 - include_tasks: 50_modify_sudo_user.yml
   tags: user
 - include_tasks: 60_enabled_services.yml 


### PR DESCRIPTION
# Description

Provisioning subnet won't get set if user skips the network task via skip-tags. To fix this, added a new tag labeled network_facts which won't get skipped if user skips network and regathers the network facts appropriately. 

Fixes #287 

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
