### PR TITLE
pull mirror information from mirror command output

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/15_disconnected_registry_create.yml
+++ b/ansible-ipi-install/roles/installer/tasks/15_disconnected_registry_create.yml
@@ -231,38 +231,6 @@
       set_fact:
         trustbundle: "{{ domain_cert_b64.content | string | b64decode }}"
   
-    - name: Create mirrorred registry information
-      set_fact:
-        install_config_appends: "{{ lookup('template', 'install-config-appends.j2') }}"
-  
-    - name: Create {{ install_config_appends_file }}
-      copy:
-        content: "{{ install_config_appends }}"
-        dest: "{{ ansible_env.HOME }}/{{ install_config_appends_file }}"
-        backup: yes
-        force: yes
-  
-    - name: Create {{ install_config_appends_file }} on localhost
-      copy:
-        content: "{{ install_config_appends }}"
-        dest: "{{ lookup ('env', 'PWD') }}/{{ install_config_appends_file }}"
-        backup: yes
-        force: yes
-      delegate_to: localhost
-  
-    - name: Information
-      debug:
-        msg:
-        - "To reuse this disconnected registry for other deployments, you must do the following:"
-        - "Add the authentication from either "
-        - "    {{ ansible_env.HOME }}/{{ registry_auth_file }} on {{ inventory_hostname }}"
-        - "    or {{ ansible_env.HOME }}/{{ registry_auth_file }} on this server to your pull secret."
-        - ""
-        - "Append the contents of either of the "
-        - "    {{ ansible_env.HOME }}/{{ install_config_appends_file }} on {{ inventory_hostname }} "
-        - "    or {{ ansible_env.HOME }}/{{ install_config_appends_file }} on this server to your"
-        - "    install-config.yaml file."
-
     - name: Create temporary pullsecret file
       copy:
         content: "{{ pullsecret }}"
@@ -278,11 +246,44 @@
           --to-release-image="{{ local_registry | quote }}/{{ local_repo | quote }}:{{ release_version | quote }}"
           --to="{{ local_registry | quote }}/{{ local_repo | quote }}"
           '
+      register: mirror_out
 
     - name: Remove temporary pullsecret file
       file:
         path: "{{ ansible_env.HOME }}/pullsecret.txt"
         state: absent
+  
+    - name: Create mirrorred registry information
+      set_fact:
+        install_config_appends: "{{ mirror_out.stdout | regex_search('(imageContentSources:[\\s\\S]*)\\n\\n\\n') }}"
+  
+    - name: Create {{ install_config_appends_file }}
+      copy:
+        content: "{{ install_config_appends }}"
+        dest: "{{ ansible_env.HOME }}/{{ install_config_appends_file }}"
+        backup: yes
+        force: yes
+  
+    - name: Create {{ install_config_appends_file }} on localhost
+      copy:
+        content: "{{ install_config_appends }}"
+        dest: "{{ lookup ('env', 'PWD') }}/{{ install_config_appends_file }}"
+        backup: yes
+        force: yes
+      delegate_to: localhost
+
+    - name: Information
+      debug:
+        msg:
+        - "To reuse this disconnected registry for other deployments, you must do the following:"
+        - "Add the authentication from either "
+        - "    {{ ansible_env.HOME }}/{{ registry_auth_file }} on {{ inventory_hostname }}"
+        - "    or {{ ansible_env.HOME }}/{{ registry_auth_file }} on this server to your pull secret."
+        - ""
+        - "Append the contents of either of the "
+        - "    {{ ansible_env.HOME }}/{{ install_config_appends_file }} on {{ inventory_hostname }} "
+        - "    or {{ ansible_env.HOME }}/{{ install_config_appends_file }} on this server to your"
+        - "    install-config.yaml file."
 
   delegate_to: "{{ groups['registry_host'][0] }}"
   tags: disconnected

--- a/ansible-ipi-install/roles/installer/templates/install-config-appends.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config-appends.j2
@@ -1,9 +1,0 @@
-additionalTrustBundle: |
-  {{ trustbundle | regex_replace('\n', '\n  ') }}
-imageContentSources:
-- mirrors:
-  - {{ local_registry }}/{{ local_repo }}
-  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-- mirrors:
-  - {{ local_registry }}/{{ local_repo }}
-  source: registry.svc.ci.openshift.org/ocp/release


### PR DESCRIPTION
# Description

This pulls the mirror information for a disconnected registry from the mirror command instead of using a j2 template. This helps insure the correct mirror information.

Fixes #294 
## Type of change

Please select the appropiate options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Created a disconnected registry and verified the install-config-appends.yml file contained the mirror information from the mirror command.

## Checklist

- [X] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [X] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
