### PR TITLE
adding flexibility mix and match ipv4 and ipv6 bridges

### DIFF
--- a/ansible-ipi-install/README.md
+++ b/ansible-ipi-install/README.md
@@ -257,6 +257,13 @@ prov_ip=172.22.0.3
 # (Optional) Enable IPv6 addressing instead of IPv4 addressing
 #ipv6_enabled=True
 
+# (Optional) When ipv6_enabled is set to True, but want IPv4 addressing on provisioning network
+# Default is false.
+#ipv4_provisioning=True
+
+# (Optional) When ipv6_enabled is set to True, but want IPv4 addressing on baremetal network
+#ipv4_baremetal=True
+
 # (Optional) A list of clock servers to be used in chrony by the masters and workers
 #clock_servers=["pool.ntp.org","clock.redhat.com"]
 

--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -37,8 +37,15 @@ prov_ip=172.22.0.3
 # (Optional) The port exposed on the caching webserver. Default is port 8080.
 #webserver_caching_port=8080
 
-# (Optional) Enable IPv6 addressing instead of IPv4 addressing
+# (Optional) Enable IPv6 addressing instead of IPv4 addressing on both provisioning and baremetal network
 #ipv6_enabled=True
+
+# (Optional) When ipv6_enabled is set to True, but want IPv4 addressing on provisioning network
+# Default is false.
+#ipv4_provisioning=True
+
+# (Optional) When ipv6_enabled is set to True, but want IPv4 addressing on baremetal network
+#ipv4_baremetal=True
 
 # (Optional) A list of clock servers to be used in chrony by the masters and workers
 #clock_servers=["pool.ntp.org","clock.redhat.com"]

--- a/ansible-ipi-install/roles/node-prep/defaults/main.yml
+++ b/ansible-ipi-install/roles/node-prep/defaults/main.yml
@@ -9,3 +9,5 @@ ipv6_enabled: false
 no_proxy_list: ""
 http_proxy: ""
 https_proxy: ""
+ipv4_baremetal: false
+ipv4_provisioning: false

--- a/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
@@ -10,6 +10,11 @@
       shell: |
         nmcli device show {{ pub_nic }} | grep GENERAL.CONNECTION | awk '{sub(/[^ ]+[ ]+/,"")}1'
       register: pub_con_name
+    
+    - name: Disconnect provisioning connection
+      command: |
+        nmcli dev dis provisioning
+      ignore_errors: yes
 
     - name: Delete {{ prov_con_name.stdout }} due to modify nmcli bug
       nmcli:
@@ -27,6 +32,11 @@
         - "{{ prov_nic }}"
         - "System {{ prov_nic }}"
       when: prov_con_name.stdout == '--' 
+
+    - name: Delete provisioning bridge if it exists
+      nmcli:
+        conn_name: provisioning
+        state: absent
     
     - name: Create Bridge labeled provisioning ipv4
       nmcli:
@@ -35,10 +45,13 @@
         ifname: provisioning
         autoconnect: yes
         ip4_method: manual
+        ip6_method: disabled
         stp: off
         ip4: 172.22.0.1/24
         state: present
-      when: not ipv6_enabled|bool or ((release_version[0]|int == 4) and (release_version[2]|int == 3))
+      when: (not ipv6_enabled|bool) or 
+            ((release_version[0]|int == 4) and (release_version[2]|int == 3)) or
+            (ipv4_provisioning|bool)
 
     - name: Create Bridge slave on {{ prov_nic }} ipv4
       nmcli:
@@ -49,7 +62,9 @@
         master: provisioning
         autoconnect: yes
         state: present
-      when: not ipv6_enabled|bool or ((release_version[0]|int == 4) and (release_version[2]|int == 3))
+      when: (not ipv6_enabled|bool) or 
+            ((release_version[0]|int == 4) and (release_version[2]|int == 3)) or
+            (ipv4_provisioning|bool)
 
     - name: Create Bridge labeled provisioning ipv6
       nmcli:
@@ -60,9 +75,13 @@
         stp: off
         ip6: fd00:1101::1/64
         state: present
+        ip4_method: disabled
         ip6_method: manual
-      when: (ipv6_enabled|bool and ((release_version[0]|int == 4) and (release_version[2]|int > 3))) or
-            (ipv6_enabled|bool and (release_version[0]|int > 4))
+      when:
+        - ipv6_enabled|bool
+        - release_version[0]|int == 4 and release_version[2]|int > 3 or
+          release_version[0]|int > 4
+        - not ipv4_provisioning|bool
 
     - name: Create Bridge slave on {{ prov_nic }} ipv6
       nmcli:
@@ -73,8 +92,11 @@
         master: provisioning
         autoconnect: yes
         state: present
-      when: (ipv6_enabled|bool and ((release_version[0]|int == 4) and (release_version[2]|int > 3))) or
-            (ipv6_enabled|bool and (release_version[0]|int > 4))
+      when:
+        - ipv6_enabled|bool
+        - release_version[0]|int == 4 and release_version[2]|int > 3 or
+          release_version[0]|int > 4
+        - not ipv4_provisioning|bool
 
     - name: Create Bridge labeled baremetal for ipv4
       nmcli:
@@ -84,7 +106,8 @@
         autoconnect: yes
         stp: off
         state: present
-      when: not ipv6_enabled|bool
+      when: (not ipv6_enabled|bool) or 
+            (ipv4_baremetal|bool)
     
     - name: Create Bridge labeled baremetal for ipv6
       nmcli:
@@ -95,7 +118,7 @@
         stp: off
         state: present
         ip6_dhcp_duid: ll
-      when: ipv6_enabled|bool
+      when: ipv6_enabled|bool and not ipv4_baremetal|bool
 
     - name: Create Bridge slave on {{ pub_nic }}
       nmcli:
@@ -114,6 +137,8 @@
       with_items:
         - baremetal
         - "{{ pub_nic }}"
+        - provisioning
+        - "{{ prov_nic }}"
   become: yes
   tags: network
 
@@ -172,3 +197,4 @@
     verbosity: 2
   tags: 
   - network_facts
+


### PR DESCRIPTION
# Description

Add the ability to have IPv4 or IPv6 mix of bridges in an environment, not just all IPv4 or all IPv6

Fixes #297 

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
