### PR TITLE
Allow to specify different prov_nic for masters

### DIFF
--- a/ansible-ipi-install/README.md
+++ b/ansible-ipi-install/README.md
@@ -278,6 +278,9 @@ dnsvip=""
 # An IP reserved on the baremetal network for the Ingress endpoint.
 # (Optional) If not set, a DNS lookup verifies that *.apps.<clustername>.<domain> provides an IP
 #ingressvip=""
+# The master hosts provisioning nic
+# (Optional) If not set, the prov_nic will be used
+#masters_prov_nic=""
 # Network Type (OpenShiftSDN or OVNKubernetes). Playbook defaults to OVNKubernetes.
 # Uncomment below for OpenShiftSDN
 #network_type="OpenShiftSDN"

--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -76,6 +76,9 @@ dnsvip=""
 # An IP reserved on the baremetal network for the Ingress endpoint.
 # (Optional) If not set, a DNS lookup verifies that *.apps.<clustername>.<domain> provides an IP
 #ingressvip=""
+# The master hosts provisioning nic
+# (Optional) If not set, the prov_nic will be used
+#masters_prov_nic=""
 # Network Type (OpenShiftSDN or OVNKubernetes). Playbook defaults to OVNKubernetes.
 # Uncomment below for OpenShiftSDN
 #network_type="OpenShiftSDN"

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -32,7 +32,7 @@ platform:
     ingressVIP: {{ ingressvip }}
     dnsVIP: {{ dnsvip }}
 {% if (release_version[0]|int > 4) or ((release_version[0]|int == 4) and (release_version[2]|int > 3)) %}
-    provisioningNetworkInterface: {{ prov_nic }}
+    provisioningNetworkInterface: {{ masters_prov_nic }}
 {% endif %}
 {% if bootstraposimage is defined and bootstraposimage|length %}
     bootstrapOSImage: {{ bootstraposimage }}

--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -194,3 +194,11 @@
   tags:
   - always
   - validation
+
+- name: Set Fact for provisioning nic
+  set_fact:
+    masters_prov_nic: "{{ prov_nic }}"
+  when: (masters_prov_nic is undefined) or (masters_prov_nic|length == 0)
+  tags:
+  - always
+  - validation


### PR DESCRIPTION
# Description

The best practice is to have same nics for provisioner and masters, but this allows more flexibility in different scenarios (labs, virtual masters,...) where the nic for the provisioner can be different while it doesn't affect the defaults either.

Fixes #296 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing
Try to run this in an heterogeneous environment where you have a modest provisioner (with embeded nics such as eno1) and beefy masters (with dedicated nics)

**Test Configuration**:

- Versions: latest 4.4
- Hardware: baremetal

## Checklist

- [x] I have performed a self-review of my own code
- [x] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
