### PR TITLE
adding correct conditionals to the subnets

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
@@ -154,7 +154,10 @@
     extcidrnet: "{{ ip | ipaddr('network') }}/{{ ip | ipaddr('prefix') }}"
   vars:
     ip: "{{ ansible_default_ipv4.address }}/{{ansible_default_ipv4.netmask }}"
-  when: (extcidrnet is not defined or extcidrnet|length < 1) and not ipv6_enabled|bool
+  when: 
+    - (extcidrnet is not defined or extcidrnet|length < 1) 
+    - not ipv6_enabled|bool or 
+      ipv4_baremetal|bool
   tags: 
   - network_facts
 
@@ -163,7 +166,10 @@
     extcidrnet: "{{ ip | ipaddr('network') }}/{{ ip | ipaddr('prefix') }}"
   vars:
     ip: "{{ ansible_default_ipv6.address }}/64"
-  when: (extcidrnet is not defined or extcidrnet|length < 1) and ipv6_enabled|bool
+  when: 
+    - (extcidrnet is not defined or extcidrnet|length < 1) 
+    - ipv6_enabled|bool
+    - not ipv4_baremetal|bool
   tags: 
   - network_facts
 
@@ -172,7 +178,10 @@
     provisioning_subnet: "{{ ip | ipaddr('network') }}/{{ ip | ipaddr('prefix') }}"
   vars:
     ip: "{{ ansible_facts.provisioning.ipv4.address }}/{{ansible_facts.provisioning.ipv4.netmask }}"
-  when: not ipv6_enabled|bool or ((release_version[0]|int == 4) and (release_version[2]|int == 3))
+  when: (not ipv6_enabled|bool) or
+        ((release_version[0]|int == 4) and (release_version[2]|int == 3)) or
+        (ipv4_provisioning|bool)
+
   tags: 
   - network_facts
 
@@ -181,8 +190,11 @@
     provisioning_subnet: "{{ ip | ipaddr('network') }}/{{ ip | ipaddr('prefix') }}"
   vars:
     ip: "{{ ansible_facts.provisioning.ipv6[0].address }}/{{ansible_facts.provisioning.ipv6[0].prefix }}"
-  when: (ipv6_enabled|bool and ((release_version[0]|int == 4) and (release_version[2]|int > 3))) or
-        (ipv6_enabled|bool and (release_version[0]|int > 4))
+  when:
+    - ipv6_enabled|bool
+    - release_version[0]|int == 4 and release_version[2]|int > 3 or
+      release_version[0]|int > 4
+    - not ipv4_provisioning|bool
   tags: 
   - network_facts
 


### PR DESCRIPTION
# Description

If using IPv6, there will be an error with capturing the provisioning subnet variable. This patch fixes that. 

Fixes #302 

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
