### PR TITLE
Use hostvars[host]['inventory_hostname'] in install-config.j2

### DIFF
--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -42,7 +42,7 @@ platform:
 {% endif %}
     hosts:
 {% for host in groups['masters'] %}
-      - name: {{ hostvars[host]['name'] }}
+      - name: {{ hostvars[host]['inventory_hostname'] }}
         role: {{ hostvars[host]['role'] }}
         bmc:
 {% if 'ipmi_port' in hostvars[host] %}
@@ -60,7 +60,7 @@ platform:
 {% endif %}
 {% endfor %}
 {% for host in groups['workers'] %}
-      - name: {{ hostvars[host]['name'] }}
+      - name: {{ hostvars[host]['inventory_hostname'] }}
         role: {{ hostvars[host]['role'] }}
         bmc:
 {% if 'ipmi_port' in hostvars[host] %}


### PR DESCRIPTION
Currently the template uses `hostvars[host]['name']` where `name`
is a hostvar set in the inventory file. However, if some other playbooks
want to consume these playbooks/roles and instead add hosts to inventory
using add_host ansible module (https://docs.ansible.com/ansible/latest/modules/add_host_module.html),
there is not really way to set the `name' hostvar as `name` is a reserved module param
in the `add_host` module and is used to supply the hostname of the new host.

Instead of changing the inventory file hostvars for master and worker groups, this commit
changes the jinja2 template making use of those vars to use `hostvars[host]['inventory_hostname']`
as that will also evaluate to master-0, worker-1 for example.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

# Description

Currently the template install-config.j2 in the installer role uses `hostvars[host]['name']` where `name`
is a hostvar set in the inventory file. However, if some other playbooks
want to consume these playbooks/roles and instead add hosts to inventory
using add_host ansible module (https://docs.ansible.com/ansible/latest/modules/add_host_module.html),
there is not really way to set the `name' hostvar as `name` is a reserved module param
in the `add_host` module and is used to supply the hostname of the new host.

Instead of changing the inventory file hostvars for master and worker groups, this commit
changes the jinja2 template making use of those vars to use `hostvars[host]['inventory_hostname']`
as that will also evaluate to master-0, worker-1 for example.


Fixes # (issue)

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
