### PR TITLE
Do not restart firewalld and use immediate

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/60_enabled_services.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/60_enabled_services.yml
@@ -1,5 +1,15 @@
 ---
-- name: Enable Services
+- name: Enable and restart Services
+  service:
+    name: "{{ item }}"
+    state: restarted
+    enabled: yes
+  become: yes
+  with_items:
+  - libvirtd
+  tags: services
+
+- name: Enable Services (iptables)
   service:
     name: "{{ item }}"
     state: restarted
@@ -7,5 +17,16 @@
   become: yes
   with_items:
   - "{{ firewall }}"
-  - libvirtd
   tags: services
+  when: firewall == "iptables"
+
+- name: Enable Services (firewalld)
+  service:
+    name: "{{ item }}"
+    state: started
+    enabled: yes
+  become: yes
+  with_items:
+  - "{{ firewall }}"
+  tags: services
+  when: firewall != "iptables"

--- a/ansible-ipi-install/roles/node-prep/tasks/70_enabled_fw_services.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/70_enabled_fw_services.yml
@@ -6,6 +6,7 @@
         service: http
         permanent: yes
         state: enabled
+        immediate: yes
       become: yes
 
     - name: Open port {{ webserver_caching_port }}/tcp, zone public, for cache for firewalld
@@ -14,17 +15,9 @@
         permanent: yes
         state: enabled
         zone: "public"
+        immediate: yes
       become: yes
       when: cache_enabled|bool
-
-    - name: Restart Firewalld
-      service:
-        name: firewalld
-        state: restarted
-        enabled: yes
-      become: yes
-  when: firewall != "iptables"
-  tags: firewall
 
 - name: Configure iptables
   block:


### PR DESCRIPTION
# Description
As we use in disconnected_registry, take steps to use immediate 'firewalld' action when defining rules an disable restart of services that are not needed.

Fixes # (issue)

Closes #293 

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
