### PR TITLE
Define reviewers and label for ansible-ipi-install folder

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,5 @@
 # See the OWNERS docs at https://go.k8s.io/owners
-  
+
 filters:
   ".*":
     reviewers:
@@ -8,3 +8,12 @@ filters:
     approvers:
       - approvers
 
+
+  "^ansible-ipi-install/.*":
+    labels:
+      - kind/installer
+    reviewers:
+      - directedsoul1
+      - iranzo
+    approvers:
+      - rlopez133


### PR DESCRIPTION
# Description

Set users for ansible-ip-install to get reviews properly tagged

This should avoid to have users not involved with ansible-ipi-install being marked as reviewers 

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

When a new PR comes in, prow should flag it properly

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
