### PR TITLE
Copying customize_filesystem to tempdir; Adding filetranspile as a local script

### DIFF
--- a/ansible-ipi-install/roles/installer/files/filetranspile-1.1.1.py
+++ b/ansible-ipi-install/roles/installer/files/filetranspile-1.1.1.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""
+Takes a fake root and appends them into a provided ignition configuration.
+"""
+
+import abc
+import argparse
+import json
+import os
+import pathlib
+import stat
+import yaml
+
+from urllib.parse import quote
+
+__version__ = '1.1.1'
+
+
+class FileTranspilerError(Exception):
+    """
+    Base exception for FileTranspiler errors.
+    """
+    pass
+
+
+class IgnitionSpec(abc.ABC):
+    """
+    Base class for IgnitionSpec classes.
+    """
+
+    def __init__(self, ignition_cfg, cli_args):
+        """
+        Initialize a spec merger.
+
+        :param ignition_cfg: loaded ignition config json
+        :type ignition_cfg: dict
+        :param cli_args: Command line arguments
+        :type cli_args: argparse.Namespace
+        """
+        self.ignition_cfg = ignition_cfg
+        self.fake_root = cli_args.fake_root
+        self.dereference_symlinks = cli_args.dereference_symlinks
+
+    @abc.abstractmethod
+    def file_to_ignition(self, file_path, file_contents, mode):
+        """
+        Turns a file into an ignition snippet.
+
+        :param file_path: Path to where the file should be placed.
+        :type file_path: str
+        :param file_contents: The raw contents of the file
+        :type file_contents: str
+        :param mode: Octal mode to use (will translate to decimal)
+        :type mode: int
+        :returns: Ignition config snippet
+        :rtype: dict
+        """
+        raise NotImplementedError('Must be implemented in a subclass')
+
+    @abc.abstractmethod
+    def link_to_ignition(self, file_path, target_path):
+        """
+        Turns a symbolic link into an ignition snippet.
+
+        :param file_path: Path to where the file should be placed.
+        :type file_path: str
+        :param target_path: The target path of the symbolic link
+        :type target_path: str
+        :returns: Ignition config snippet
+        :rtype: dict
+        """
+        raise NotImplementedError('Must be implemented in a subclass')
+
+    def merge_with_ignition(self, ignition_cfg, files, links):
+        """
+        Merge file snippets into the ignition config.
+
+        :param ignition_cfg: Ignition structure to append to
+        :type ignition_cfg: dict
+        :param files: List of Ignition file snippets
+        :type files: list
+        :returns: Merged ignition dict
+        :rtype: dict
+        """
+        # Check that the storage exists
+        storage_check = ignition_cfg.get('storage')
+        if storage_check is None:
+            ignition_cfg['storage'] = {}
+
+        if files:
+            # Check that files entry exists
+            files_check = ignition_cfg['storage'].get('files')
+            if files_check is None:
+                ignition_cfg['storage']['files'] = []
+
+            for a_file in files:
+                ignition_cfg['storage']['files'].append(a_file)
+
+        if links:
+            # Check that links entry exists
+            links_check = ignition_cfg['storage'].get('links')
+            if links_check is None:
+                ignition_cfg['storage']['links'] = []
+
+            for a_link in links:
+                ignition_cfg['storage']['links'].append(a_link)
+
+        return ignition_cfg
+
+    def merge(self):
+        """
+        Merges the fakeroot into the ignition config.
+
+        :returns: The merged ignition config
+        :rtype: dict
+        """
+        # Walk through the files and append them for merging
+        all_files = []
+        all_links = []
+        for root, _, files in os.walk(self.fake_root):
+            for file in files:
+                path = os.path.sep.join([root, file])
+                host_path = path.replace(self.fake_root, '')
+                if not host_path.startswith(os.path.sep):
+                    host_path = os.path.sep + host_path
+                if os.path.islink(path):
+                    # If we are dereferencing symlinks then treat it as
+                    # a file
+                    if self.dereference_symlinks:
+                        source_path = str(pathlib.Path(path).resolve())
+                        # Ensure the path is within the fakeroot
+                        if not source_path.startswith(
+                                os.path.realpath(self.fake_root)):
+                            raise FileTranspilerError(
+                                'link: {} is not in the fake root: {}'.format(
+                                    source_path, self.fake_root))
+                        mode = oct(stat.S_IMODE(os.stat(source_path).st_mode))
+                        with open(source_path, 'r') as file_obj:
+                            snippet = self.file_to_ignition(
+                                host_path, file_obj.read(), mode)
+                            all_files.append(snippet)
+                    else:
+                        target_path = os.readlink(path)
+                        snippet = self.link_to_ignition(
+                            host_path, target_path)
+                        all_links.append(snippet)
+                else:
+                    mode = oct(stat.S_IMODE(os.stat(path).st_mode))
+                    with open(path, 'r') as file_obj:
+                        snippet = self.file_to_ignition(
+                            host_path, file_obj.read(), mode)
+                    all_files.append(snippet)
+
+        # Merge the and output the results
+        merged_ignition = self.merge_with_ignition(
+            self.ignition_cfg, all_files, all_links)
+        return merged_ignition
+
+
+class SpecV2(IgnitionSpec):
+    """
+    Spec v2 implementation for merging files.
+    """
+
+    def file_to_ignition(self, file_path, file_contents, mode):
+        """
+        Turns a file into an ignition snippet.
+
+        :param file_path: Path to where the file should be placed.
+        :type file_path: str
+        :param file_contents: The raw contents of the file
+        :type file_contents: str
+        :param mode: Octal mode to use (will translate to decimal)
+        :type mode: int
+        :returns: Ignition config snippet
+        :rtype: dict
+        """
+        return {
+            'path': file_path,
+            "filesystem": 'root',
+            'mode': int(mode, 8),
+            'contents': {
+                'source': 'data:,{}'.format(quote(file_contents))
+            }
+        }
+
+    def link_to_ignition(self, file_path, target_path):
+        """
+        Turns a symbolic link into an ignition snippet.
+
+        :param file_path: Path to where the file should be placed.
+        :type file_path: str
+        :param target_path: The target path of the symbolic link
+        :type target_path: str
+        :returns: Ignition config snippet
+        :rtype: dict
+        """
+        return {
+            'path': file_path,
+            "filesystem": 'root',
+            'target' : target_path,
+            'hard': False
+        }
+
+
+class SpecV3(IgnitionSpec):
+    """
+    Spec v3 implementation for merging files.
+    """
+
+    def file_to_ignition(self, file_path, file_contents, mode):
+        """
+        Turns a file into an ignition snippet.
+
+        :param file_path: Path to where the file should be placed.
+        :type file_path: str
+        :param file_contents: The raw contents of the file
+        :type file_contents: str
+        :param mode: Octal mode to use (will translate to decimal)
+        :type mode: int
+        :returns: Ignition config snippet
+        :rtype: dict
+        """
+        return {
+            'path': file_path,
+            'mode': int(mode, 8),
+            'overwrite': True,
+            'contents': {
+                'source': 'data:,{}'.format(quote(file_contents))
+            }
+        }
+
+    def link_to_ignition(self, file_path, target_path):
+        """
+        Turns a symbolic link into an ignition snippet.
+
+        :param file_path: Path to where the file should be placed.
+        :type file_path: str
+        :param target_path: The target path of the symbolic link
+        :type target_path: str
+        :returns: Ignition config snippet
+        :rtype: dict
+        """
+        return {
+            'path': file_path,
+            'overwrite': True,
+            'target' : target_path,
+            'hard': False
+        }
+
+
+def loader(ignition_file):
+    """
+    Loads the ignition json into a structure, senses the ignition
+    spec version, and returns the structure and it's spec class.
+
+    :param ignition_file: Path to the ignition file to parse
+    :type ignition_file: str
+    :returns: The ignition structure and spec class
+    :rtype: tuple
+    :raises: FileTranspilerError
+    """
+    try:
+        with open(ignition_file, 'r') as f:
+            ignition_cfg = json.load(f)
+        ignition_version = ignition_cfg['ignition']['version']
+        version_tpl = ignition_version.split('.')
+
+        if version_tpl[0] == '2':
+            return ignition_cfg, SpecV2
+        elif version_tpl[0] == '3':
+            return ignition_cfg, SpecV3
+        raise FileTranspilerError(
+            'Unkown ignition spec: {}'.format(ignition_version))
+    except (KeyError, IndexError) as err:
+        raise FileTranspilerError(
+            'Unable to find version in spec: {}'.format(err))
+    except json.JSONDecodeError as err:
+        raise FileTranspilerError(
+            'Unable to read JSON: {}'.format(err))
+
+
+def main():
+    """
+    Main entry point
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-i', '--ignition', help='Path to ignition file to use as the base')
+    parser.add_argument(
+        '-f', '--fake-root', help='Path to the fake root',
+        required=True)
+    parser.add_argument(
+        '-o', '--output',
+        help='Where to output the file. If empty, will print to stdout')
+    parser.add_argument(
+        '-p', '--pretty', default=False, action='store_true',
+        help='Make the output pretty')
+    parser.add_argument(
+        '--dereference-symlinks', default=False, action='store_true',
+        help=('Write out file contents instead of making symlinks '
+              'NOTE: Target files must exist in the fakeroot'))
+    parser.add_argument(
+        '--format', default='json', choices=['json', 'yaml'],
+        help='What format of file to write out. `yaml` or `json` (default)')
+    parser.add_argument(
+        '--version', action='version',
+        version='%(prog)s {}'.format(__version__))
+
+    args = parser.parse_args()
+
+    # Open the base ignition file and load it
+    if args.ignition is not None:
+        # Get the ignition config
+        try:
+            ignition_cfg, spec_cls = loader(args.ignition)
+            ignition_spec = spec_cls(ignition_cfg, args)
+            
+        except FileTranspilerError as err:
+            parser.error(err)
+    else:
+        # Default to empty spec 2.3.0
+        ignition_cfg = { "ignition": { "version": "2.3.0" } }
+        ignition_spec = SpecV2(ignition_cfg, args)
+
+    # Merge the and output the results
+    merged_ignition = ignition_spec.merge()
+
+    if args.format == 'json':
+        if args.pretty:
+            ignition_out = json.dumps(
+                merged_ignition, sort_keys=True,
+                indent=4, separators=(',', ': '))
+        else:
+            ignition_out = json.dumps(merged_ignition)
+    else:
+        ignition_out = yaml.safe_dump(merged_ignition)
+    if args.output:
+        with open(args.output, 'w') as out_f:
+            out_f.write(ignition_out)
+    else:
+        print(ignition_out)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible-ipi-install/roles/installer/tasks/35_customize_filesystem.yml
+++ b/ansible-ipi-install/roles/installer/tasks/35_customize_filesystem.yml
@@ -18,12 +18,6 @@
     shell: |
       /usr/local/bin/openshift-baremetal-install --dir {{ dir }} create ignition-configs
 
-  - name: Get Filetranspiler
-    get_url:
-      url: https://raw.githubusercontent.com/ashcrow/filetranspiler/1.1.1/filetranspile
-      dest: "{{ tempdir }}/filetranspile.py"
-      mode: '0755'
-
   - name: Copy Ignition Config Files
     copy:
       src: "{{ dir }}/{{ item }}.ign"
@@ -32,9 +26,15 @@
       - "master"
       - "worker"
 
+  - name: Copy customize_filesystem to tempdir
+    copy:
+      src: "{{ role_path }}/files/customize_filesystem"
+      dest: "{{ tempdir }}"
+      force: yes
+
   - name: Cleanup Any .gitkeep Files in the Fake Root
     file:
-      path: "{{ role_path }}/files/customize_filesystem/{{ item }}/.gitkeep"
+      path: "{{ tempdir }}/customize_filesystem/{{ item }}/.gitkeep"
       state: absent
       follow: yes
     with_items:
@@ -43,8 +43,10 @@
     become: true
 
   - name: Augment Ignition Config Files
-    shell: |
-      {{ tempdir }}/filetranspile.py -i {{ dir }}/{{ item }}.ign.orig -f {{ role_path }}/files/customize_filesystem/{{ item }} -o {{ dir }}/{{ item }}.ign
+    script: |
+      filetranspile-1.1.1.py -i {{ dir }}/{{ item }}.ign.orig -f {{ tempdir }}/customize_filesystem/{{ item }} -o {{ dir }}/{{ item }}.ign
+    args:
+      executable: python3
     with_items:
       - "master"
       - "worker"


### PR DESCRIPTION
# Description

The current approach to the customize_filesystem and filetranspile assumes that the ansible playbook is being run locally on the provisioning host. If the playbook is run from a remote host, the task will not complete correctly because the "fake" root path isn't on the provisoning host where the filetranspile command is run.

The fix inserts a task to always copy the fake root to a tempdir, and then executes the filetranspile script remotely against the tempdir path.

Also, the filetranspile binary was chagned from being downloaded with each run from git to now having the version 1.1.1 of the script included directly in the role.

Fixes #322

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ x ] Tested as run locally on the provision host
- [ x ] Tested as run remotely

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ x ] I have performed a self-review of my own code
- [ x ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ x ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ x ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ x ] PRs should not be merged unless positively reviewed.
