### PR TITLE
Add remote_src for copying ignition files

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/55_customize_filesystem.yml
+++ b/ansible-ipi-install/roles/installer/tasks/55_customize_filesystem.yml
@@ -22,6 +22,7 @@
     copy:
       src: "{{ dir }}/{{ item }}.ign"
       dest: "{{ dir }}/{{ item }}.ign.orig"
+      remote_src: yes
     with_items:
       - "master"
       - "worker"


### PR DESCRIPTION
# Description
https://github.com/openshift-kni/baremetal-deploy/pull/323 accounted for possibility of executing the playbook and filetranspile work from a remote host, however this task needs remote_src for that to work. Otherwise we will see,

```
TASK [installer : Copy Ignition Config Files] ************************************************************************************************************************************************************************************************
Monday 27 April 2020  14:21:48 -0400 (0:00:06.775)       0:26:06.009 ********** 
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: If you are using a module and expect the file to exist on the remote, see the remote_src option
failed: [provisioner] (item=master) => {"ansible_loop_var": "item", "changed": false, "item": "master", "msg": "Could not find or access '/home/kni/clusterconfigs/master.ign' on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: If you are using a module and expect the file to exist on the remote, see the remote_src option
failed: [provisioner] (item=worker) => {"ansible_loop_var": "item", "changed": false, "item": "worker", "msg": "Could not find or access '/home/kni/clusterconfigs/worker.ign' on the Ansible Controller.\nIf you are using a module and expect the file to exist on the remote, see the remote_src option"}
```