### PR TITLE
Take backup of ignition files used by installer

### DIFF
--- a/ansible-ipi-install/README.md
+++ b/ansible-ipi-install/README.md
@@ -114,9 +114,9 @@ The tree structure is shown below:
     │   │   ├── 24_rhcos_image_cache.yml
     │   │   ├── 25_create-install-config.yml
     │   │   ├── 30_create_metal3.yml
-    │   │   ├── 35_customize_filesystem.yml
     │   │   ├── 40_create_manifest.yml
     │   │   ├── 50_extramanifests.yml
+    │   │   ├── 55_customize_filesystem.yml
     │   │   ├── 59_cleanup_bootstrap.yml
     │   │   ├── 60_deploy_ocp.yml
     │   │   ├── 70_cleanup_sub_man_registeration.yml

--- a/ansible-ipi-install/roles/installer/tasks/55_customize_filesystem.yml
+++ b/ansible-ipi-install/roles/installer/tasks/55_customize_filesystem.yml
@@ -56,6 +56,18 @@
   when: (filesFound | json_query('results[*].matched') | sum) > 0
   tags: customfs
 
+- name: Create backup of ignition config files
+  copy:
+    src: "{{ dir }}/{{ item }}.ign"
+    dest: "{{ dir }}/{{ item }}.ign.bkup"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: '0644'
+    remote_src: yes
+  with_items:
+    - "master"
+    - "worker"
+
 - name: Delete tmp dir as no longer needed
   file:
     path: "{{ tempdir }}"


### PR DESCRIPTION
# Description

This commit allows for taking backups of the ignition config files used by the installer for debug laster on. This feature is similar to taking backup of the install-config.yaml.