### PR TITLE
add parameter for provisioning bridge name

### DIFF
--- a/ansible-ipi-install/README.md
+++ b/ansible-ipi-install/README.md
@@ -231,6 +231,9 @@ prov_nic=eno1
 # The public NIC (NIC2) used on all baremetal nodes
 pub_nic=eno2
 
+# (Optional) Set the provisioning bridge name. Default value is 'provisioning'. 
+#provisioning_bridge=provisioning
+
 # (Optional) Activation-key for proper setup of subscription-manager, empty value skips registration
 #activation_key=""
 

--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -10,6 +10,9 @@ prov_nic=eno1
 # The public NIC (NIC2) used on all baremetal nodes
 pub_nic=eno2
 
+# (Optional) Set the provisioning bridge name. Default value is 'provisioning'. 
+#provisioning_bridge=provisioning
+
 # (Optional) Activation-key for proper setup of subscription-manager, empty value skips registration
 #activation_key=""
 

--- a/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
+++ b/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
@@ -49,13 +49,13 @@
 
 - name: Set bootstrap image URL override if not provided by the user
   set_fact:
-    bootstraposimage: "http://{{ ansible_provisioning.ipv4.address }}:{{ webserver_caching_port }}/{{ rhcos_qemu_uri }}?sha256={{ rhcos_qemu_sha256_unzipped }}"
+    bootstraposimage: "http://{{ ansible_facts[provisioning_bridge]['ipv4']['address'] }}:{{ webserver_caching_port }}/{{ rhcos_qemu_uri }}?sha256={{ rhcos_qemu_sha256_unzipped }}"
   when: bootstraposimage is not defined or bootstraposimage|length < 1
   tags: cache
 
 - name: Set cluster image URL override if not provided by the user
   set_fact:
-    clusterosimage: "http://{{ ansible_provisioning.ipv4.address }}:{{ webserver_caching_port }}/{{ rhcos_uri }}?sha256={{ rhcos_sha256 }}"
+    clusterosimage: "http://{{ ansible_facts[provisioning_bridge]['ipv4']['address'] }}:{{ webserver_caching_port }}/{{ rhcos_uri }}?sha256={{ rhcos_sha256 }}"
   when: clusterosimage is not defined or clusterosimage|length < 1
   tags: cache
 

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -31,6 +31,7 @@ platform:
     apiVIP: {{ apivip }}
     ingressVIP: {{ ingressvip }}
     dnsVIP: {{ dnsvip }}
+    provisioningBridge: {{ provisioning_bridge }}
 {% if (release_version[0]|int > 4) or ((release_version[0]|int == 4) and (release_version[2]|int > 3)) %}
     provisioningNetworkInterface: {{ masters_prov_nic }}
 {% endif %}

--- a/ansible-ipi-install/roles/node-prep/defaults/main.yml
+++ b/ansible-ipi-install/roles/node-prep/defaults/main.yml
@@ -11,3 +11,4 @@ http_proxy: ""
 https_proxy: ""
 ipv4_baremetal: false
 ipv4_provisioning: false
+provisioning_bridge: "provisioning"

--- a/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
@@ -11,9 +11,9 @@
         nmcli device show {{ pub_nic }} | grep GENERAL.CONNECTION | awk '{sub(/[^ ]+[ ]+/,"")}1'
       register: pub_con_name
 
-    - name: Disconnect provisioning connection
+    - name: Disconnect "{{ provisioning_bridge }}" connection
       command: |
-        nmcli dev dis provisioning
+        nmcli dev dis "{{ provisioning_bridge }}"
       ignore_errors: yes
 
     - name: Delete {{ prov_con_name.stdout }} due to modify nmcli bug
@@ -33,16 +33,16 @@
         - "System {{ prov_nic }}"
       when: prov_con_name.stdout == '--'
 
-    - name: Delete provisioning bridge if it exists
+    - name: Delete "{{ provisioning_bridge }}" bridge if it exists
       nmcli:
-        conn_name: provisioning
+        conn_name: "{{ provisioning_bridge }}"
         state: absent
 
-    - name: Create Bridge labeled provisioning ipv4
+    - name: Create Bridge labeled "{{ provisioning_bridge }}" ipv4
       nmcli:
-        conn_name: provisioning
+        conn_name: "{{ provisioning_bridge }}"
         type: bridge
-        ifname: provisioning
+        ifname: "{{ provisioning_bridge }}"
         autoconnect: yes
         ip4_method: manual
         ip6_method: disabled
@@ -59,18 +59,18 @@
         type: bridge-slave
         hairpin: no
         ifname: "{{ prov_nic }}"
-        master: provisioning
+        master: "{{ provisioning_bridge }}"
         autoconnect: yes
         state: present
       when: (not ipv6_enabled|bool) or
             ((release_version[0]|int == 4) and (release_version[2]|int == 3)) or
             (ipv4_provisioning|bool)
 
-    - name: Create Bridge labeled provisioning ipv6
+    - name: Create Bridge labeled "{{ provisioning_bridge }}" ipv6
       nmcli:
-        conn_name: provisioning
+        conn_name: "{{ provisioning_bridge }}"
         type: bridge
-        ifname: provisioning
+        ifname: "{{ provisioning_bridge }}"
         autoconnect: yes
         stp: off
         ip6: fd00:1101::1/64
@@ -89,7 +89,7 @@
         type: bridge-slave
         hairpin: no
         ifname: "{{ prov_nic }}"
-        master: provisioning
+        master: "{{ provisioning_bridge }}"
         autoconnect: yes
         state: present
       when:
@@ -137,7 +137,7 @@
       with_items:
         - baremetal
         - "{{ pub_nic }}"
-        - provisioning
+        - "{{ provisioning_bridge }}"
         - "{{ prov_nic }}"
   become: yes
   tags: network

--- a/ansible-ipi-install/roles/node-prep/tasks/45_networking_facts.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/45_networking_facts.yml
@@ -34,7 +34,7 @@
   set_fact:
     provisioning_subnet: "{{ ip | ipaddr('network') }}/{{ ip | ipaddr('prefix') }}"
   vars:
-    ip: "{{ ansible_facts.provisioning.ipv4.address }}/{{ansible_facts.provisioning.ipv4.netmask }}"
+    ip: "{{ ansible_facts[provisioning_bridge]['ipv4']['address'] }}/{{ ansible_facts[provisioning_bridge]['ipv4']['netmask'] }}"
   when: (not ipv6_enabled|bool) or
         ((release_version[0]|int == 4) and (release_version[2]|int == 3)) or
         (ipv4_provisioning|bool)
@@ -45,7 +45,7 @@
   set_fact:
     provisioning_subnet: "{{ ip | ipaddr('network') }}/{{ ip | ipaddr('prefix') }}"
   vars:
-    ip: "{{ ansible_facts.provisioning.ipv6[0].address }}/{{ansible_facts.provisioning.ipv6[0].prefix }}"
+    ip: "{{ ansible_facts[provisioning_bridge]['ipv6'][0]['address'] }}/{{ansible_facts[provisioning_bridge]['ipv6'][0]['prefix'] }}"
   when:
     - ipv6_enabled|bool
     - release_version[0]|int == 4 and release_version[2]|int > 3 or


### PR DESCRIPTION
# Description

Adding parametrers for bridge names 
instead of hardcoded 'provisioning' and 'baremetal'

so it can be used in more complex envirionment such as when provisioning host have a 801q nic with multiple provisioining/baremetal networks.

- [X ] New feature (non-breaking change which adds functionality)


Closes #226