### PR TITLE
[doc] Changing path of where domain.crt is located in provision host

### DIFF
--- a/documentation/modules/ipi-install-creating-a-disconnected-registry.adoc
+++ b/documentation/modules/ipi-install-creating-a-disconnected-registry.adoc
@@ -207,7 +207,7 @@ On the provisioner node, the `install-config.yaml` file should use the newly cre
 ----
 [kni@provisioner ~]$ scp user@registry.example.com:/opt/registry/certs/domain.crt /home/kni
 [kni@provisioner ~]$ echo "additionalTrustBundle: |" >> install-config.yaml
-[kni@provisioner ~]$ sed -e 's/^/  /' /opt/registry/certs/domain.crt >> install-config.yaml
+[kni@provisioner ~]$ sed -e 's/^/  /' /home/kni/domain.crt >> install-config.yaml
 ----
 
 . Add the mirror information for the registry to the `install-config.yaml` file.


### PR DESCRIPTION
# Description

Changing path of where domain.crt is located in provision host

Fixes #341 
## Type of change

Please select the appropiate options:

- [x] This change requires a documentation update


## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
