### PR TITLE
Added required logic for proper setting IPv6 settings

### DIFF
--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -11,7 +11,7 @@ metadata:
 networking:
   machineCIDR: {{ extcidrnet }}
   networkType: {{ network_type }}
-{% if ipv6_enabled|bool %}
+{% if ipv6_enabled|bool and not ipv4_baremetal|bool %}
   clusterNetwork:
   - cidr: fd01::/48
     hostPrefix: 64


### PR DESCRIPTION
# Description

When enabling both ipv6_enabled=True and ipv4_baremetal=True you get the

  clusterNetwork:
  - cidr: fd01::/48
    hostPrefix: 64
  serviceNetwork:
  - fd02::/112

to be set within the install-config. Need to fix this so its not included when ipv4_baremetal is set to True

Fixes #343 

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
