### PR TITLE
move backup of ignition configs to inside block

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/55_customize_filesystem.yml
+++ b/ansible-ipi-install/roles/installer/tasks/55_customize_filesystem.yml
@@ -53,23 +53,17 @@
       - "worker"
     become: true
 
+  - name: Create backup of ignition config files
+    copy:
+      src: "{{ dir }}/{{ item }}.ign"
+      dest: "{{ dir }}/{{ item }}.ign.bkup"
+      owner: "{{ ansible_user }}"
+      group: "{{ ansible_user }}"
+      mode: '0644'
+      remote_src: yes
+    with_items:
+      - "master"
+      - "worker"
+
   when: (filesFound | json_query('results[*].matched') | sum) > 0
-  tags: customfs
-
-- name: Create backup of ignition config files
-  copy:
-    src: "{{ dir }}/{{ item }}.ign"
-    dest: "{{ dir }}/{{ item }}.ign.bkup"
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    mode: '0644'
-    remote_src: yes
-  with_items:
-    - "master"
-    - "worker"
-
-- name: Delete tmp dir as no longer needed
-  file:
-    path: "{{ tempdir }}"
-    state: absent
   tags: customfs


### PR DESCRIPTION
# Description

Move the task to backup ignition config files inside the conditional block that generates the files so that they are only backed up if they exist. Also remove the task to delete the tempdir as it could break subsequent tasks that could be added in the future.

Fixes #345 

## Type of change

Please select the appropiate options:

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Not directly tested, but a pretty straightforward change.

## Checklist

- [ x ] I have performed a self-review of my own code
- [ x ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ x ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ x ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ x ] PRs should not be merged unless positively reviewed.
