### PR TITLE
Make workers group in inventory optional

### DIFF
--- a/ansible-ipi-install/README.md
+++ b/ansible-ipi-install/README.md
@@ -389,8 +389,6 @@ NOTE: The `ipmi_port` examples above show how a user can specify a different `ip
 
 NOTE: A detailed description of the `vars` under the section `Vars regarding install-config.yaml` may be reviewed within [Configure the install-config and metal3-config](https://github.com/openshift-kni/baremetal-deploy/blob/master/install-steps.md#configure-the-install-config-and-metal3-config) if unsure how to populate.
 
-WARNING: If no `workers` are included, do not remove the workers group (`[workers]`) as it is required to properly build the `install-config.yaml` file.
-
 ## The Ansible `playbook.yml`
 
 The Ansible playbook connects to your provision host and runs through the `node-prep` role and the `installer` role. No modification is necessary. All modifications of variables may be done within the `inventory/hosts` file. A sample file is located in this repository under `inventory/hosts.sample`.

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -59,6 +59,7 @@ platform:
         hardwareProfile: default
 {% endif %}
 {% endfor %}
+{% if groups['workers'] is defined %}
 {% for host in groups['workers'] %}
       - name: {{ hostvars[host]['inventory_hostname'] }}
         role: {{ hostvars[host]['role'] }}
@@ -77,6 +78,7 @@ platform:
         hardwareProfile: unknown
 {% endif %}
 {% endfor %}
+{% endif %}
 pullSecret: '{{ pullsecret }}'
 sshKey: '{{ key }}'
 {% if install_config_appends is defined and install_config_appends|length %}

--- a/ansible-ipi-install/roles/node-prep/tasks/100_power_off_cluster_servers.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/100_power_off_cluster_servers.yml
@@ -10,7 +10,7 @@
         or  ( hostvars[item]['poweroff']|bool | default(True) )
       with_items:
         - "{{ groups.masters }}"
-        - "{{ groups.workers }}"
+        - "{{ groups.workers | default([]) }}"
 
     - name: Power off hosts
       ipmi_power:

--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -163,18 +163,15 @@
 
 - name: Fail if hostgroups not defined in inventory/hosts file
   fail:
-    msg: "The {{ item }} group is not defined. Please add [{{ item }}] to the inventory/hosts file"
-  when: "'{{ item }}' not in groups"
-  loop:
-    - masters
-    - workers
+    msg: "The masters group is not defined. Please add masters to the inventory/hosts file"
+  when: "'masters' not in groups"
   tags:
   - always
   - validation
 
 - name: Set Fact of num of workers and masters based on inventory
   set_fact:
-    numworkers: "{{ groups['workers'] | length }}"
+    numworkers: "{{ groups['workers'] | default([]) | length }}"
     nummasters: "{{ groups['masters'] | length }}"
   tags:
   - always


### PR DESCRIPTION
This is useful if user wants to deploy a masters only setup.

# Description

Right now it is possible for a user to deploy a masters only setup, but even then an empty group must be defined in the inventory as

```
[workers]
```

as several tasks, templates depend on the workers group name being defined.  This commit removed the need to define workers group in inventory when deploying only masters
Fixes #348 

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Testing with no workers group defined in inventory