### PR TITLE
Fix gulp development to point to new paths and create fake index.html

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -9,13 +9,11 @@ import terser from "gulp-terser";
 
 const browserSync = browserSyncCreate();
 
-const path404 = path.join(__dirname, "website/_site/404.html");
+const path404 = path.join(__dirname, "website/404.html");
 const content_404 = () =>
   fs.existsSync(path404) ? fs.readFileSync(path404) : null;
 
-const cleanOutput = () => exec("rm -rf website/_site/*");
-
-const buildContent = () => exec("utils/build.sh");
+const buildContent = () => exec("utils/build-gulp.sh");
 
 const reload = (cb) => {
   browserSync.init(
@@ -24,12 +22,12 @@ const reload = (cb) => {
         port: 9002,
       },
       server: {
-        baseDir: "website/_site/",
+        baseDir: "website/",
         serveStaticOptions: {
           extensions: ["html"],
         },
       },
-      files: "website/_site/*.html",
+      files: "website/*.html",
       port: 9001,
     },
     (_, bs) => {

--- a/utils/build-gulp.sh
+++ b/utils/build-gulp.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Builds documentation for each release in both HTML and PDF versions
+
+sh utils/build.sh
+
+myreleases=$(cat website/_data/releases.yml | grep name | cut -d ":" -f 2- | xargs)
+
+# Empty index
+>website/index.html
+
+echo "<ul>" >>website/index.html
+for release in ${myreleases}; do
+    echo "<li><a href=\"${release}\">${release}</a></li>" >>website/index.html
+done
+
+echo "</ul>" >>website/index.html


### PR DESCRIPTION
# Description

When changing the paths to simplify website generation, gulpfile required to recover some of the features like fake index.html generation and path updates.


Fixes # (issue)

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
