### PR TITLE
Fixing API VIP and Ingress VIP verifications

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -91,11 +91,18 @@
     verbosity: 2
   tags: validation
 
-- name: Verify DNS records for API VIP, Wildcard (Ingress) VIP
+- name: Verify DNS records for Wildcard (Ingress) VIP
+  set_fact:
+    ingressvip: "{{ lookup('dig', 'foo.apps.{{ cluster |quote }}.{{ domain | quote }}.', '{{ qtype }}' )}}"
+  when: ((ingressvip is undefined) or (ingressvip|length == 0))
+  tags:
+  - always
+  - validation
+
+- name: Verify DNS records for API VIP
   set_fact:
     apivip: "{{ lookup('dig', 'api.{{ cluster |quote }}.{{ domain | quote }}.', '{{ qtype }}' )}}"
-    ingressvip: "{{ lookup('dig', 'foo.apps.{{ cluster |quote }}.{{ domain | quote }}.', '{{ qtype }}' )}}"
-  when: ((apivip is undefined) or (ingressvip is undefined) or (apivip|length == 0) or (ingressvip|length == 0))
+  when: ((apivip is undefined) or (apivip|length == 0))
   tags:
   - always
   - validation
@@ -114,16 +121,16 @@
 
 - name: Fail if incorrect API VIP
   fail:
-    msg: "The API VIP IP seems to be incorrect. Value was NXDOMAIN."
-  when: (apivip == 'NXDOMAIN')
+    msg: "The API VIP IP seems to be incorrect. Value was NXDOMAIN or empty string."
+  when: (apivip == 'NXDOMAIN') or (apivip|length == 0)
   tags:
   - always
   - validation
 
 - name: Fail if incorrect Ingress VIP
   fail:
-    msg: "The Ingress VIP IP seems to be incorrect. Value was NXDOMAIN."
-  when: (ingressvip == 'NXDOMAIN')
+    msg: "The Ingress VIP IP seems to be incorrect. Value was NXDOMAIN or empty string."
+  when: (ingressvip == 'NXDOMAIN') or (ingressvip|length == 0)
   tags:
   - always
   - validation

--- a/ansible-ipi-install/roles/node-prep/vars/main.yml
+++ b/ansible-ipi-install/roles/node-prep/vars/main.yml
@@ -24,7 +24,7 @@ package_list:
 cache_package_list:
   - podman
 
-qtype: "{{ 'qtype=AAAA' if ipv6_enabled is defined and ipv6_enabled|bool else 'qtype=A' }}"
+qtype: "{{ (ipv6_enabled|bool and ipv4_baremetal|bool) | ternary('qtype=A', 'qtype=AAAA') }}"
 
 # Temporary state variables for disconnected registry
 drm_set: false


### PR DESCRIPTION
# Description

Currently the API and Ingress VIP verification had faulty logic. Fixed the logic so that they are accurately called and also found an issue where the qtype was not properly being set when a mix and match of IPv6 and IPv4 networking was setup. 

Fixes #391 

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
