### PR TITLE
Clean up nmcli scripts

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-nmcli-setup.adoc
+++ b/documentation/ipi-install/modules/ipi-install-nmcli-setup.adoc
@@ -11,18 +11,24 @@ This step can also be run from the web console.
 [kni@provisioner ~]$ export PUB_CONN=<baremetal_nic_name>
 [kni@provisioner ~]$ export PROV_CONN=<prov_nic_name>
 [kni@provisioner ~]$ sudo nohup bash -c '
-    nmcli con down "$PROV_CONN"
     nmcli con down "$PUB_CONN"
-    nmcli con delete "$PROV_CONN"
     nmcli con delete "$PUB_CONN"
     # RHEL 8.1 appends the word "System" in front of the connection, delete in case it exists
     nmcli con down "System $PUB_CONN"
     nmcli con delete "System $PUB_CONN"
-    nmcli connection add ifname provisioning type bridge con-name provisioning
-    nmcli con add type bridge-slave ifname "$PROV_CONN" master provisioning
     nmcli connection add ifname baremetal type bridge con-name baremetal
     nmcli con add type bridge-slave ifname "$PUB_CONN" master baremetal
-    nmcli con down "$PUB_CONN";pkill dhclient;dhclient baremetal
+    nmcli con down baremetal
+    nmcli con up baremetal
+'
+[kni@provisioner ~]$ sudo nohup bash -c '
+    nmcli con down "$PROV_CONN"
+    nmcli con delete "$PROV_CONN"
+    # RHEL 8.1 appends the word "System" in front of the connection, delete in case it exists
+    nmcli con down "System $PROV_CONN"
+    nmcli con delete "System $PROV_CONN"
+    nmcli connection add ifname provisioning type bridge con-name provisioning
+    nmcli con add type bridge-slave ifname "$PROV_CONN" master provisioning
     nmcli connection modify provisioning ipv6.addresses fd00:1101::1/64 ipv6.method manual
     nmcli con down provisioning
     nmcli con up provisioning
@@ -31,7 +37,7 @@ This step can also be run from the web console.
 +
 [NOTE]
 ====
-The `ssh` connection may disconnect after executing this step.
+The `ssh` connection may disconnect after executing this step. You will want to have some sort of out-of-band connection to your host (eg., a serial console, local keyboard, or dedicated management interface) in the event that something goes wrong while executing these commands.
 
 The IPv6 address may be any address as long as it is not routable via the `baremetal` network.
 


### PR DESCRIPTION
The existing `nmcli` script jumbled together commands for the
baremetal and provisioning network, making it difficult to understand
exactly what was going on. There were also some commands that were
effectively "hidden" after a semicolon which weren't immediately
obvious when inspecting the script.

This changes splits up the nmcli scripts into two commands (one for the baremetal
network, one for the provisioning network), and replaces the direct
manipulation of `dhclient` with `nmcli con down` and `nmcli con up`
commands.