### PR TITLE
Update docs to suggest some additional package installs

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/documentation/ipi-install/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -13,11 +13,11 @@ If you are running the installer on a network with limited bandwidth and the RHC
 Use the following steps to install a container that contains the images.
 
 
-. Install `podman`.
+. Install `podman` and `policycoreutils-python-utils`.
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ sudo dnf install -y podman
+[kni@provisioner ~]$ sudo dnf install -y podman policycoreutils-python-utils
 ----
 
 . Open firewall port `8080` to be used for RHCOS Image caching.

--- a/documentation/ipi-install/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
+++ b/documentation/ipi-install/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
@@ -53,7 +53,7 @@ For more information about Red Hat Subscription Manager, see link:https://access
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ sudo dnf install -y libvirt qemu-kvm mkisofs python3-devel jq ipmitool
+[kni@provisioner ~]$ sudo dnf install -y libvirt qemu-kvm mkisofs python3-devel jq ipmitool tar
 ----
 
 . Modify the user to add the `libvirt` group to the newly created user.


### PR DESCRIPTION
The steps in the documentation make assumptions about what software
might be installed by default. With a minimal install, `tar`
and tools like `semange` and `restore` may not be available.