### PR TITLE
Only poweroff if poweroff_servers has a host in it

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/100_power_off_cluster_servers.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/100_power_off_cluster_servers.yml
@@ -19,5 +19,6 @@
         password: "{{ hostvars[item]['ipmi_password'] }}"
         port: "{{ hostvars[item]['ipmi_port'] | default(623) }}"
         state: off
+      when: groups['poweroff_hosts'] is defined
       with_items: "{{ groups['poweroff_hosts'] }}"
   tags: powerservers


### PR DESCRIPTION
Signed-off-by: Johnny Bieren <jbieren@redhat.com>

# Description

Only call the task to power off all servers in the poweroff_servers group if at least one host was added to it. Otherwise, you get an error because the group won't actually exist.

## Type of change

Please select the appropiate options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

- [ ] Tested locally

**Test Configuration**:

- Versions: RHEL-8.1
- Hardware: Virtual

## Checklist

- [X] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
