### PR TITLE
Ensuring that cache and registry containers autostart upon reboot

### DIFF
--- a/ansible-ipi-install/roles/installer/defaults/main.yml
+++ b/ansible-ipi-install/roles/installer/defaults/main.yml
@@ -13,3 +13,4 @@ webserver_caching_port: "{{ webserver_caching_port_container }}"
 webserver_caching_port_container: 8080
 registry_creation: false
 url_passed: false
+httpd_cache_files: "{{ provision_cache_store }}httpd/"

--- a/ansible-ipi-install/roles/installer/tasks/15_disconnected_registry_create.yml
+++ b/ansible-ipi-install/roles/installer/tasks/15_disconnected_registry_create.yml
@@ -272,10 +272,8 @@
       podman_container:
         name: "{{ pod_name_registry }}"
         image: docker.io/library/registry:2
-        state: started
+        state: stopped
         network: host
-        publish:
-          - "{{ registry_port }}:{{ registry_port_container }}"
         volumes:
           - "{{ registry_dir_data }}:/var/lib/registry:z"
           - "{{ registry_dir_auth }}:/auth:z"
@@ -287,7 +285,64 @@
           REGISTRY_AUTH_HTPASSWD_PATH: auth/htpasswd
           REGISTRY_HTTP_TLS_CERTIFICATE: certs/domain.crt
           REGISTRY_HTTP_TLS_KEY: certs/domain.key
+      register: registry_container_info
 
+    - name: Setting facts about container
+      set_fact:
+        container_registry_name: "{{ registry_container_info.ansible_facts.podman_container.Name }}"
+        container_registry_pidfile: "{{ registry_container_info.ansible_facts.podman_container.ConmonPidFile }}"
+
+    - name: Ensure user specific systemd instance are persistent
+      command:  |
+              /usr/bin/loginctl enable-linger {{ ansible_user }}
+
+    - name: Create systemd user directory
+      file:
+        path: "{{ ansible_user_dir }}/.config/systemd/user"
+        state: directory
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: '0775'
+
+    - name: Copy the systemd service file
+      copy:
+        content: |
+          [Unit]
+          Description=Podman container-registry.service
+          [Service]
+          Restart=on-failure
+          ExecStart=/usr/bin/podman start {{ container_registry_name }}
+          ExecStop=/usr/bin/podman stop -t 10 {{ container_registry_name }}
+          KillMode=none
+          Type=forking
+          PIDFile={{ container_registry_pidfile }}
+          [Install]
+          WantedBy=default.target
+        dest: "{{ ansible_user_dir }}/.config/systemd/user/container-registry.service"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: '0644'
+
+    - name: Reload systemd service
+      systemd:
+        daemon_reexec: yes
+        scope: user
+      environment:
+        DBUS_SESSION_BUS_ADDRESS: "{{ ansible_env.DBUS_SESSION_BUS_ADDRESS|default('unix:path=/run/user/' +  ansible_effective_user_id|string + '/bus') }}"
+    - name: Enable container-registry.service
+      systemd:
+        name: container-registry
+        enabled: yes
+        scope: user
+      environment:
+        DBUS_SESSION_BUS_ADDRESS: "{{ ansible_env.DBUS_SESSION_BUS_ADDRESS|default('unix:path=/run/user/' +  ansible_effective_user_id|string + '/bus') }}"
+    - name: Start container-registry.service
+      systemd:
+        name: container-registry
+        state: started
+        scope: user
+      environment:
+        DBUS_SESSION_BUS_ADDRESS: "{{ ansible_env.DBUS_SESSION_BUS_ADDRESS|default('unix:path=/run/user/' +  ansible_effective_user_id|string + '/bus') }}"
     - name: Read in the contents of domain.crt
       slurp:
         src: "{{ registry_dir_cert }}/domain.crt"

--- a/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
+++ b/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
@@ -11,13 +11,6 @@
   register: the_url
   tags: cache
 
-#- name: Default url_passed to false
-#  set_fact:
-#    url_passed: false
-#  when:
-#    - the_url.status == -1
-#  tags: cache
-
 - name: Check if url status is 200 is true
   set_fact:
    url_passed : true
@@ -59,14 +52,32 @@
     - disconnected_installer|length == 0
   tags: cache
 
-- name: Create {{ provision_cache_store }} on host with online access
+#SELinux when already has httpd_sys_content_t giving issues changing,thus leaving it the same
+#for the provision_cache_store to prevent issues. Also removing ":z" from podman_container for 
+#provision_cache_store in the later task.   
+- name: Create {{ provision_cache_store }} and {{ httpd_cache_files }} on host with online access
   file:
-    path: "{{ provision_cache_store }}"
+    path: "{{ item[0] }}"
     state: directory
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
-    mode: '0755'
-    setype: httpd_sys_content_t
+    setype: "{{ item[1] }}"
+    mode: '0775'
+  with_nested:
+    - [ "{{ provision_cache_store }}" , "{{ httpd_cache_files }}" ]
+    - [ 'httpd_sys_content_t', '_default' ]
+  delegate_to: "{{ url_passed | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
+  tags: cache
+
+- name: Add magic and httpd.conf file to {{ httpd_cache_files }} dir
+  template:
+    src: "{{ item[0] }}"
+    dest: "{{ httpd_cache_files }}/{{ item[1] }}"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+  with_nested:
+    - [ 'magic.j2', 'httpd_conf.j2' ]
+    - [ 'magic', 'httpd.conf' ]
   delegate_to: "{{ url_passed | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
   tags: cache
 
@@ -109,7 +120,6 @@
   #use the hostname from the inventory to groups[registry][0] or provisioner[0] as the http://URL
   #use a ternary to toggle between the url status
   #use a ternary for the delegate_to
-  #
 - name: Get URL of host providing the webserver
   set_fact:
     host_url: "{{ the_url.status == 200 | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
@@ -129,24 +139,91 @@
   delegate_to: "{{ url_passed | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
   tags: cache
 
-- name: What thebootstraposimage
+- name: BootstrapOSImage Details
   debug:
     msg: "{{ bootstraposimage }}"
+    verbosity: 2
 
-- name: the clusterosimage
+- name: ClusterOSImage Details
   debug:
     msg: "{{ clusterosimage }}"
+    verbosity: 2
 
-
+#Leaving SELinux details alone and not using ":z"
+#for the provision_cache_store due to issues attempting
+#to revert context. Leaving behavior as it was previously
+#to avoid breaking other user environments.
 - name: Start RHCOS image cache container
   podman_container:
     name: rhcos_image_cache
     image: registry.centos.org/centos/httpd-24-centos7:latest
-    state: started
+    state: stopped
     network: host
-    publish:
-      - "{{ webserver_caching_port }}:{{ webserver_caching_port_container  }}"
     volumes:
       - "{{ provision_cache_store }}:/var/www/html"
+      - "{{ httpd_cache_files }}:/opt/rh/httpd24/root/etc/httpd/conf:z"
   delegate_to: "{{ url_passed | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
   tags: cache
+  register: rhcos_image_cache_info
+
+- name: Setting facts about container
+  set_fact:
+    rhcos_image_cache_name: "{{ rhcos_image_cache_info.ansible_facts.podman_container.Name }}"
+    rhcos_image_cache_pidfile: "{{ rhcos_image_cache_info.ansible_facts.podman_container.ConmonPidFile }}"
+  tags: cache
+
+- name: Ensuring container restarts upon reboot
+  block:
+    - name: Ensure user specific systemd instance are persistent
+      command:  |
+              /usr/bin/loginctl enable-linger {{ ansible_user }}
+ 
+    - name: Create systemd user directory
+      file:
+        path: "{{ ansible_user_dir }}/.config/systemd/user"
+        state: directory
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: '0775'
+    
+    - name: Copy the systemd service file
+      copy:
+        content: |
+          [Unit]
+          Description=Podman container-cache.service
+          [Service]
+          Restart=on-failure
+          ExecStart=/usr/bin/podman start {{ rhcos_image_cache_name }}
+          ExecStop=/usr/bin/podman stop -t 10 {{ rhcos_image_cache_name }}
+          KillMode=none
+          Type=forking
+          PIDFile={{ rhcos_image_cache_pidfile }}
+          [Install]
+          WantedBy=default.target
+        dest: "{{ ansible_user_dir }}/.config/systemd/user/container-cache.service"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: '0644'
+    
+    - name: Reload systemd service
+      systemd:
+        daemon_reexec: yes
+        scope: user
+      environment: 
+        DBUS_SESSION_BUS_ADDRESS: "{{ ansible_env.DBUS_SESSION_BUS_ADDRESS|default('unix:path=/run/user/' +  ansible_effective_user_id|string + '/bus') }}"
+    - name: Enable container-cache.service
+      systemd:
+        name: container-cache.service
+        enabled: yes
+        scope: user
+      environment: 
+        DBUS_SESSION_BUS_ADDRESS: "{{ ansible_env.DBUS_SESSION_BUS_ADDRESS|default('unix:path=/run/user/' +  ansible_effective_user_id|string + '/bus') }}"
+    - name: Start container-cache.service
+      systemd:
+        name: container-cache.service
+        state: started
+        scope: user
+      environment: 
+        DBUS_SESSION_BUS_ADDRESS: "{{ ansible_env.DBUS_SESSION_BUS_ADDRESS|default('unix:path=/run/user/' +  ansible_effective_user_id|string + '/bus') }}"
+  tags: cache
+  delegate_to: "{{ url_passed | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"

--- a/ansible-ipi-install/roles/installer/templates/httpd_conf.j2
+++ b/ansible-ipi-install/roles/installer/templates/httpd_conf.j2
@@ -1,0 +1,355 @@
+# This is the main Apache HTTP server configuration file.  It contains the
+# configuration directives that give the server its instructions.
+# See <URL:http://httpd.apache.org/docs/2.4/> for detailed information.
+# In particular, see 
+# <URL:http://httpd.apache.org/docs/2.4/mod/directives.html>
+# for a discussion of each configuration directive.
+#
+# Do NOT simply read the instructions in here without understanding
+# what they do.  They're here only as hints or reminders.  If you are unsure
+# consult the online docs. You have been warned.  
+#
+# Configuration and logfile names: If the filenames you specify for many
+# of the server's control files begin with "/" (or "drive:/" for Win32), the
+# server will use that explicit path.  If the filenames do *not* begin
+# with "/", the value of ServerRoot is prepended -- so 'log/access_log'
+# with ServerRoot set to '/www' will be interpreted by the
+# server as '/www/log/access_log', where as '/log/access_log' will be
+# interpreted as '/log/access_log'.
+
+#
+# ServerRoot: The top of the directory tree under which the server's
+# configuration, error, and log files are kept.
+#
+# Do not add a slash at the end of the directory path.  If you point
+# ServerRoot at a non-local disk, be sure to specify a local disk on the
+# Mutex directive, if file-based mutexes are used.  If you wish to share the
+# same ServerRoot for multiple httpd daemons, you will need to change at
+# least PidFile.
+#
+ServerRoot "/opt/rh/httpd24/root/etc/httpd"
+
+#
+# Listen: Allows you to bind Apache to specific IP addresses and/or
+# ports, instead of the default. See also the <VirtualHost>
+# directive.
+#
+# Change this to Listen on specific IP addresses as shown below to 
+# prevent Apache from glomming onto all bound IP addresses.
+#
+#Listen 12.34.56.78:80
+Listen 0.0.0.0:{{ webserver_caching_port_container }}
+Listen [::]:{{ webserver_caching_port_container }}
+
+#
+# Dynamic Shared Object (DSO) Support
+#
+# To be able to use the functionality of a module which was built as a DSO you
+# have to place corresponding `LoadModule' lines at this location so the
+# directives contained in it are actually available _before_ they are used.
+# Statically compiled modules (those listed by `httpd -l') do not need
+# to be loaded here.
+#
+# Example:
+# LoadModule foo_module modules/mod_foo.so
+#
+Include conf.modules.d/*.conf
+
+#
+# If you wish httpd to run as a different user or group, you must run
+# httpd as root initially and it will switch.  
+#
+# User/Group: The name (or #number) of the user/group to run httpd as.
+# It is usually good practice to create a dedicated user and group for
+# running httpd, as with most system services.
+#
+User default
+Group root
+
+# 'Main' server configuration
+#
+# The directives in this section set up the values used by the 'main'
+# server, which responds to any requests that aren't handled by a
+# <VirtualHost> definition.  These values also provide defaults for
+# any <VirtualHost> containers you may define later in the file.
+#
+# All of these directives may appear inside <VirtualHost> containers,
+# in which case these default settings will be overridden for the
+# virtual host being defined.
+#
+
+#
+# ServerAdmin: Your address, where problems with the server should be
+# e-mailed.  This address appears on some server-generated pages, such
+# as error documents.  e.g. admin@your-domain.com
+#
+ServerAdmin root@localhost
+
+#
+# ServerName gives the name and port that the server uses to identify itself.
+# This can often be determined automatically, but we recommend you specify
+# it explicitly to prevent problems during startup.
+#
+# If your host doesn't have a registered DNS name, enter its IP address here.
+#
+#ServerName www.example.com:80
+
+#
+# Deny access to the entirety of your server's filesystem. You must
+# explicitly permit access to web content directories in other 
+# <Directory> blocks below.
+#
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+
+#
+# Note that from this point forward you must specifically allow
+# particular features to be enabled - so if something's not working as
+# you might expect, make sure that you have specifically enabled it
+# below.
+#
+
+#
+# DocumentRoot: The directory out of which you will serve your
+# documents. By default, all requests are taken from this directory, but
+# symbolic links and aliases may be used to point to other locations.
+#
+DocumentRoot "/opt/rh/httpd24/root/var/www/html"
+
+#
+# Relax access to content within /opt/rh/httpd24/root/var/www.
+#
+<Directory "/opt/rh/httpd24/root/var/www">
+    AllowOverride None
+    # Allow open access:
+    Require all granted
+</Directory>
+
+# Further relax access to the default document root:
+<Directory "/opt/rh/httpd24/root/var/www/html">
+    #
+    # Possible values for the Options directive are "None", "All",
+    # or any combination of:
+    #   Indexes Includes FollowSymLinks SymLinksifOwnerMatch ExecCGI MultiViews
+    #
+    # Note that "MultiViews" must be named *explicitly* --- "Options All"
+    # doesn't give it to you.
+    #
+    # The Options directive is both complicated and important.  Please see
+    # http://httpd.apache.org/docs/2.4/mod/core.html#options
+    # for more information.
+    #
+    Options Indexes FollowSymLinks
+
+    #
+    # AllowOverride controls what directives may be placed in .htaccess files.
+    # It can be "All", "None", or any combination of the keywords:
+    #   Options FileInfo AuthConfig Limit
+    #
+    AllowOverride All
+
+    #
+    # Controls who can get stuff from this server.
+    #
+    Require all granted
+</Directory>
+
+#
+# DirectoryIndex: sets the file that Apache will serve if a directory
+# is requested.
+#
+<IfModule dir_module>
+    DirectoryIndex index.html
+</IfModule>
+
+#
+# The following lines prevent .htaccess and .htpasswd files from being 
+# viewed by Web clients. 
+#
+<Files ".ht*">
+    Require all denied
+</Files>
+
+#
+# ErrorLog: The location of the error log file.
+# If you do not specify an ErrorLog directive within a <VirtualHost>
+# container, error messages relating to that virtual host will be
+# logged here.  If you *do* define an error logfile for a <VirtualHost>
+# container, that host's errors will be logged there and not here.
+#
+ErrorLog |/usr/bin/cat
+
+#
+# LogLevel: Control the number of messages logged to the error_log.
+# Possible values include: debug, info, notice, warn, error, crit,
+# alert, emerg.
+#
+LogLevel warn
+
+<IfModule log_config_module>
+    #
+    # The following directives define some format nicknames for use with
+    # a CustomLog directive (see below).
+    #
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+    <IfModule logio_module>
+      # You need to enable mod_logio.c to use %I and %O
+      LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+    </IfModule>
+
+    #
+    # The location and format of the access logfile (Common Logfile Format).
+    # If you do not define any access logfiles within a <VirtualHost>
+    # container, they will be logged here.  Contrariwise, if you *do*
+    # define per-<VirtualHost> access logfiles, transactions will be
+    # logged therein and *not* in this file.
+    #
+    #CustomLog "logs/access_log" common
+
+    #
+    # If you prefer a logfile with access, agent, and referer information
+    # (Combined Logfile Format) you can use the following directive.
+    #
+    CustomLog |/usr/bin/cat combined
+</IfModule>
+
+<IfModule alias_module>
+    #
+    # Redirect: Allows you to tell clients about documents that used to 
+    # exist in your server's namespace, but do not anymore. The client 
+    # will make a new request for the document at its new location.
+    # Example:
+    # Redirect permanent /foo http://www.example.com/bar
+
+    #
+    # Alias: Maps web paths into filesystem paths and is used to
+    # access content that does not live under the DocumentRoot.
+    # Example:
+    # Alias /webpath /full/filesystem/path
+    #
+    # If you include a trailing / on /webpath then the server will
+    # require it to be present in the URL.  You will also likely
+    # need to provide a <Directory> section to allow access to
+    # the filesystem path.
+
+    #
+    # ScriptAlias: This controls which directories contain server scripts. 
+    # ScriptAliases are essentially the same as Aliases, except that
+    # documents in the target directory are treated as applications and
+    # run by the server when requested rather than as documents sent to the
+    # client.  The same rules about trailing "/" apply to ScriptAlias
+    # directives as to Alias.
+    #
+    ScriptAlias /cgi-bin/ "/opt/rh/httpd24/root/var/www/cgi-bin/"
+
+</IfModule>
+
+#
+# "/opt/rh/httpd24/root/var/www/cgi-bin" should be changed to whatever your ScriptAliased
+# CGI directory exists, if you have that configured.
+#
+<Directory "/opt/rh/httpd24/root/var/www/cgi-bin">
+    AllowOverride None
+    Options None
+    Require all granted
+</Directory>
+
+<IfModule mime_module>
+    #
+    # TypesConfig points to the file containing the list of mappings from
+    # filename extension to MIME-type.
+    #
+    TypesConfig /etc/mime.types
+
+    #
+    # AddType allows you to add to or override the MIME configuration
+    # file specified in TypesConfig for specific file types.
+    #
+    #AddType application/x-gzip .tgz
+    #
+    # AddEncoding allows you to have certain browsers uncompress
+    # information on the fly. Note: Not all browsers support this.
+    #
+    #AddEncoding x-compress .Z
+    #AddEncoding x-gzip .gz .tgz
+    #
+    # If the AddEncoding directives above are commented-out, then you
+    # probably should define those extensions to indicate media types:
+    #
+    AddType application/x-compress .Z
+    AddType application/x-gzip .gz .tgz
+
+    #
+    # AddHandler allows you to map certain file extensions to "handlers":
+    # actions unrelated to filetype. These can be either built into the server
+    # or added with the Action directive (see below)
+    #
+    # To use CGI scripts outside of ScriptAliased directories:
+    # (You will also need to add "ExecCGI" to the "Options" directive.)
+    #
+    #AddHandler cgi-script .cgi
+
+    # For type maps (negotiated resources):
+    #AddHandler type-map var
+
+    #
+    # Filters allow you to process content before it is sent to the client.
+    #
+    # To parse .shtml files for server-side includes (SSI):
+    # (You will also need to add "Includes" to the "Options" directive.)
+    #
+    AddType text/html .shtml
+    AddOutputFilter INCLUDES .shtml
+</IfModule>
+
+#
+# Specify a default charset for all content served; this enables
+# interpretation of all content as UTF-8 by default.  To use the 
+# default browser choice (ISO-8859-1), or to allow the META tags
+# in HTML content to override this choice, comment out this
+# directive:
+#
+AddDefaultCharset UTF-8
+
+<IfModule mime_magic_module>
+    #
+    # The mod_mime_magic module allows the server to use various hints from the
+    # contents of the file itself to determine its type.  The MIMEMagicFile
+    # directive tells the module where the hint definitions are located.
+    #
+    MIMEMagicFile conf/magic
+</IfModule>
+
+#
+# Customizable error responses come in three flavors:
+# 1) plain text 2) local redirects 3) external redirects
+#
+# Some examples:
+#ErrorDocument 500 "The server made a boo boo."
+#ErrorDocument 404 /missing.html
+#ErrorDocument 404 "/cgi-bin/missing_handler.pl"
+#ErrorDocument 402 http://www.example.com/subscription_info.html
+#
+
+#
+# EnableMMAP and EnableSendfile: On systems that support it, 
+# memory-mapping or the sendfile syscall may be used to deliver
+# files.  This usually improves server performance, but must
+# be turned off when serving from networked-mounted 
+# filesystems or if support for these functions is otherwise
+# broken on your system.
+# Defaults if commented: EnableMMAP On, EnableSendfile Off
+#
+#EnableMMAP off
+EnableSendfile on
+
+# Supplemental configuration
+#
+# Load config files in the "/etc/httpd/conf.d" directory, if any.
+IncludeOptional conf.d/*.conf
+
+

--- a/ansible-ipi-install/roles/installer/templates/magic.j2
+++ b/ansible-ipi-install/roles/installer/templates/magic.j2
@@ -1,0 +1,385 @@
+# Magic data for mod_mime_magic Apache module (originally for file(1) command)
+# The module is described in /manual/mod/mod_mime_magic.html
+#
+# The format is 4-5 columns:
+#    Column #1: byte number to begin checking from, ">" indicates continuation
+#    Column #2: type of data to match
+#    Column #3: contents of data to match
+#    Column #4: MIME type of result
+#    Column #5: MIME encoding of result (optional)
+
+#------------------------------------------------------------------------------
+# Localstuff:  file(1) magic for locally observed files
+# Add any locally observed files here.
+
+#------------------------------------------------------------------------------
+# end local stuff
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# Java
+
+0	short		0xcafe
+>2	short		0xbabe		application/java
+
+#------------------------------------------------------------------------------
+# audio:  file(1) magic for sound formats
+#
+# from Jan Nicolai Langfeldt <janl@ifi.uio.no>,
+#
+
+# Sun/NeXT audio data
+0	string		.snd
+>12	belong		1		audio/basic
+>12	belong		2		audio/basic
+>12	belong		3		audio/basic
+>12	belong		4		audio/basic
+>12	belong		5		audio/basic
+>12	belong		6		audio/basic
+>12	belong		7		audio/basic
+
+>12	belong		23		audio/x-adpcm
+
+# DEC systems (e.g. DECstation 5000) use a variant of the Sun/NeXT format
+# that uses little-endian encoding and has a different magic number
+# (0x0064732E in little-endian encoding).
+0	lelong		0x0064732E	
+>12	lelong		1		audio/x-dec-basic
+>12	lelong		2		audio/x-dec-basic
+>12	lelong		3		audio/x-dec-basic
+>12	lelong		4		audio/x-dec-basic
+>12	lelong		5		audio/x-dec-basic
+>12	lelong		6		audio/x-dec-basic
+>12	lelong		7		audio/x-dec-basic
+#                                       compressed (G.721 ADPCM)
+>12	lelong		23		audio/x-dec-adpcm
+
+# Bytes 0-3 of AIFF, AIFF-C, & 8SVX audio files are "FORM"
+#					AIFF audio data
+8	string		AIFF		audio/x-aiff	
+#					AIFF-C audio data
+8	string		AIFC		audio/x-aiff	
+#					IFF/8SVX audio data
+8	string		8SVX		audio/x-aiff	
+
+# Creative Labs AUDIO stuff
+#					Standard MIDI data
+0	string	MThd			audio/unknown	
+#>9 	byte	>0			(format %d)
+#>11	byte	>1			using %d channels
+#					Creative Music (CMF) data
+0	string	CTMF			audio/unknown	
+#					SoundBlaster instrument data
+0	string	SBI			audio/unknown	
+#					Creative Labs voice data
+0	string	Creative\ Voice\ File	audio/unknown	
+## is this next line right?  it came this way...
+#>19	byte	0x1A
+#>23	byte	>0			- version %d
+#>22	byte	>0			\b.%d
+
+# [GRR 950115:  is this also Creative Labs?  Guessing that first line
+#  should be string instead of unknown-endian long...]
+#0	long		0x4e54524b	MultiTrack sound data
+#0	string		NTRK		MultiTrack sound data
+#>4	long		x		- version %ld
+
+# Microsoft WAVE format (*.wav)
+# [GRR 950115:  probably all of the shorts and longs should be leshort/lelong]
+#					Microsoft RIFF
+0	string		RIFF		audio/unknown
+#					- WAVE format
+>8	string		WAVE		audio/x-wav
+# MPEG audio.
+0   beshort&0xfff0  0xfff0  audio/mpeg
+# C64 SID Music files, from Linus Walleij <triad@df.lth.se>
+0   string      PSID        audio/prs.sid
+
+#------------------------------------------------------------------------------
+# c-lang:  file(1) magic for C programs or various scripts
+#
+
+# XPM icons (Greg Roelofs, newt@uchicago.edu)
+# ideally should go into "images", but entries below would tag XPM as C source
+0	string		/*\ XPM		image/x-xbm	7bit
+
+# this first will upset you if you're a PL/1 shop... (are there any left?)
+# in which case rm it; ascmagic will catch real C programs
+#					C or REXX program text
+0	string		/*		text/plain
+#					C++ program text
+0	string		//		text/plain
+
+#------------------------------------------------------------------------------
+# compress:  file(1) magic for pure-compression formats (no archives)
+#
+# compress, gzip, pack, compact, huf, squeeze, crunch, freeze, yabba, whap, etc.
+#
+# Formats for various forms of compressed data
+# Formats for "compress" proper have been moved into "compress.c",
+# because it tries to uncompress it to figure out what's inside.
+
+# standard unix compress
+0	string		\037\235	application/octet-stream	x-compress
+
+# gzip (GNU zip, not to be confused with [Info-ZIP/PKWARE] zip archiver)
+0       string          \037\213        application/octet-stream	x-gzip
+
+# According to gzip.h, this is the correct byte order for packed data.
+0	string		\037\036	application/octet-stream
+#
+# This magic number is byte-order-independent.
+#
+0	short		017437		application/octet-stream
+
+# XXX - why *two* entries for "compacted data", one of which is
+# byte-order independent, and one of which is byte-order dependent?
+#
+# compacted data
+0	short		0x1fff		application/octet-stream
+0	string		\377\037	application/octet-stream
+# huf output
+0	short		0145405		application/octet-stream
+
+# Squeeze and Crunch...
+# These numbers were gleaned from the Unix versions of the programs to
+# handle these formats.  Note that I can only uncrunch, not crunch, and
+# I didn't have a crunched file handy, so the crunch number is untested.
+#				Keith Waclena <keith@cerberus.uchicago.edu>
+#0	leshort		0x76FF		squeezed data (CP/M, DOS)
+#0	leshort		0x76FE		crunched data (CP/M, DOS)
+
+# Freeze
+#0	string		\037\237	Frozen file 2.1
+#0	string		\037\236	Frozen file 1.0 (or gzip 0.5)
+
+# lzh?
+#0	string		\037\240	LZH compressed data
+
+#------------------------------------------------------------------------------
+# frame:  file(1) magic for FrameMaker files
+#
+# This stuff came on a FrameMaker demo tape, most of which is
+# copyright, but this file is "published" as witness the following:
+#
+0	string		\<MakerFile	application/x-frame
+0	string		\<MIFFile	application/x-frame
+0	string		\<MakerDictionary	application/x-frame
+0	string		\<MakerScreenFon	application/x-frame
+0	string		\<MML		application/x-frame
+0	string		\<Book		application/x-frame
+0	string		\<Maker		application/x-frame
+
+#------------------------------------------------------------------------------
+# html:  file(1) magic for HTML (HyperText Markup Language) docs
+#
+# from Daniel Quinlan <quinlan@yggdrasil.com>
+# and Anna Shergold <anna@inext.co.uk>
+#
+0   string      \<!DOCTYPE\ HTML    text/html
+0   string      \<!doctype\ html    text/html
+0   string      \<HEAD      text/html
+0   string      \<head      text/html
+0   string      \<TITLE     text/html
+0   string      \<title     text/html
+0   string      \<html      text/html
+0   string      \<HTML      text/html
+0   string      \<!--       text/html
+0   string      \<h1        text/html
+0   string      \<H1        text/html
+
+# XML eXtensible Markup Language, from Linus Walleij <triad@df.lth.se>
+0   string      \<?xml      text/xml
+
+#------------------------------------------------------------------------------
+# images:  file(1) magic for image formats (see also "c-lang" for XPM bitmaps)
+#
+# originally from jef@helios.ee.lbl.gov (Jef Poskanzer),
+# additions by janl@ifi.uio.no as well as others. Jan also suggested
+# merging several one- and two-line files into here.
+#
+# XXX - byte order for GIF and TIFF fields?
+# [GRR:  TIFF allows both byte orders; GIF is probably little-endian]
+#
+
+# [GRR:  what the hell is this doing in here?]
+#0	string		xbtoa		btoa'd file
+
+# PBMPLUS
+#					PBM file
+0	string		P1		image/x-portable-bitmap	7bit
+#					PGM file
+0	string		P2		image/x-portable-greymap	7bit
+#					PPM file
+0	string		P3		image/x-portable-pixmap	7bit
+#					PBM "rawbits" file
+0	string		P4		image/x-portable-bitmap
+#					PGM "rawbits" file
+0	string		P5		image/x-portable-greymap
+#					PPM "rawbits" file
+0	string		P6		image/x-portable-pixmap
+
+# NIFF (Navy Interchange File Format, a modification of TIFF)
+# [GRR:  this *must* go before TIFF]
+0	string		IIN1		image/x-niff
+
+# TIFF and friends
+#					TIFF file, big-endian
+0	string		MM		image/tiff
+#					TIFF file, little-endian
+0	string		II		image/tiff
+
+# possible GIF replacements; none yet released!
+# (Greg Roelofs, newt@uchicago.edu)
+#
+# GRR 950115:  this was mine ("Zip GIF"):
+#					ZIF image (GIF+deflate alpha)
+0	string		GIF94z		image/unknown
+#
+# GRR 950115:  this is Jeremy Wohl's Free Graphics Format (better):
+#					FGF image (GIF+deflate beta)
+0	string		FGF95a		image/unknown
+#
+# GRR 950115:  this is Thomas Boutell's Portable Bitmap Format proposal
+# (best; not yet implemented):
+#					PBF image (deflate compression)
+0	string		PBF		image/unknown
+
+# GIF
+0	string		GIF		image/gif
+
+# JPEG images
+0	beshort		0xffd8		image/jpeg
+
+# PC bitmaps (OS/2, Windoze BMP files)  (Greg Roelofs, newt@uchicago.edu)
+0	string		BM		image/bmp
+#>14	byte		12		(OS/2 1.x format)
+#>14	byte		64		(OS/2 2.x format)
+#>14	byte		40		(Windows 3.x format)
+#0	string		IC		icon
+#0	string		PI		pointer
+#0	string		CI		color icon
+#0	string		CP		color pointer
+#0	string		BA		bitmap array
+
+0	string		\x89PNG		image/png
+0	string		FWS		application/x-shockwave-flash
+0	string		CWS		application/x-shockwave-flash
+
+#------------------------------------------------------------------------------
+# lisp:  file(1) magic for lisp programs
+#
+# various lisp types, from Daniel Quinlan (quinlan@yggdrasil.com)
+0	string	;;			text/plain	8bit
+# Emacs 18 - this is always correct, but not very magical.
+0	string	\012(			application/x-elc
+# Emacs 19
+0	string	;ELC\023\000\000\000	application/x-elc
+
+#------------------------------------------------------------------------------
+# mail.news:  file(1) magic for mail and news
+#
+# There are tests to ascmagic.c to cope with mail and news.
+0	string		Relay-Version: 	message/rfc822	7bit
+0	string		#!\ rnews	message/rfc822	7bit
+0	string		N#!\ rnews	message/rfc822	7bit
+0	string		Forward\ to 	message/rfc822	7bit
+0	string		Pipe\ to 	message/rfc822	7bit
+0	string		Return-Path:	message/rfc822	7bit
+0	string		Path:		message/news	8bit
+0	string		Xref:		message/news	8bit
+0	string		From:		message/rfc822	7bit
+0	string		Article 	message/news	8bit
+#------------------------------------------------------------------------------
+# msword: file(1) magic for MS Word files
+#
+# Contributor claims:
+# Reversed-engineered MS Word magic numbers
+#
+
+0	string		\376\067\0\043			application/msword
+0	string		\333\245-\0\0\0			application/msword
+
+# disable this one because it applies also to other
+# Office/OLE documents for which msword is not correct. See PR#2608.
+#0	string		\320\317\021\340\241\261	application/msword
+
+
+
+#------------------------------------------------------------------------------
+# printer:  file(1) magic for printer-formatted files
+#
+
+# PostScript
+0	string		%!		application/postscript
+0	string		\004%!		application/postscript
+
+# Acrobat
+# (due to clamen@cs.cmu.edu)
+0	string		%PDF-		application/pdf
+
+#------------------------------------------------------------------------------
+# sc:  file(1) magic for "sc" spreadsheet
+#
+38	string		Spreadsheet	application/x-sc
+
+#------------------------------------------------------------------------------
+# tex:  file(1) magic for TeX files
+#
+# XXX - needs byte-endian stuff (big-endian and little-endian DVI?)
+#
+# From <conklin@talisman.kaleida.com>
+
+# Although we may know the offset of certain text fields in TeX DVI
+# and font files, we can't use them reliably because they are not
+# zero terminated. [but we do anyway, christos]
+0	string		\367\002	application/x-dvi
+#0	string		\367\203	TeX generic font data
+#0	string		\367\131	TeX packed font data
+#0	string		\367\312	TeX virtual font data
+#0	string		This\ is\ TeX,	TeX transcript text	
+#0	string		This\ is\ METAFONT,	METAFONT transcript text
+
+# There is no way to detect TeX Font Metric (*.tfm) files without
+# breaking them apart and reading the data.  The following patterns
+# match most *.tfm files generated by METAFONT or afm2tfm.
+#2	string		\000\021	TeX font metric data
+#2	string		\000\022	TeX font metric data
+#>34	string		>\0		(%s)
+
+# Texinfo and GNU Info, from Daniel Quinlan (quinlan@yggdrasil.com)
+#0	string		\\input\ texinfo	Texinfo source text
+#0	string		This\ is\ Info\ file	GNU Info text
+
+# correct TeX magic for Linux (and maybe more)
+# from Peter Tobias (tobias@server.et-inf.fho-emden.de)
+#
+0	leshort		0x02f7		application/x-dvi
+
+# RTF - Rich Text Format
+0	string		{\\rtf		application/rtf
+
+#------------------------------------------------------------------------------
+# animation:  file(1) magic for animation/movie formats
+#
+# animation formats, originally from vax@ccwf.cc.utexas.edu (VaX#n8)
+#						MPEG file
+0	string		\000\000\001\263	video/mpeg
+#
+# The contributor claims:
+#   I couldn't find a real magic number for these, however, this
+#   -appears- to work.  Note that it might catch other files, too,
+#   so BE CAREFUL!
+#
+# Note that title and author appear in the two 20-byte chunks
+# at decimal offsets 2 and 22, respectively, but they are XOR'ed with
+# 255 (hex FF)! DL format SUCKS BIG ROCKS.
+#
+#						DL file version 1 , medium format (160x100, 4 images/screen)
+0	byte		1			video/unknown
+0	byte		2			video/unknown
+# Quicktime video, from Linus Walleij <triad@df.lth.se>
+# from Apple quicktime file format documentation.
+4   string      moov        video/quicktime
+4   string      mdat        video/quicktime
+

--- a/documentation/ansible-playbook/modules/ansible-playbook-failed-to-connect-to-bus-no-file-or-directory.adoc
+++ b/documentation/ansible-playbook/modules/ansible-playbook-failed-to-connect-to-bus-no-file-or-directory.adoc
@@ -1,0 +1,42 @@
+[id="ansible-playbook-failed-to-connect-to-bus-no-file-or-directory"]
+
+= Failed to connect to bus: No such file or directory
+
+The Ansible playbook creates two containers (when enabled) to 
+store a mirored registry and a caching webserver. 
+When these containers are created, the playbook also creates a
+`systemd` unit file to ensure these containers are restarted upon
+the reboot of the host serving them. 
+
+Since these are `systemd` user services, when logging into a
+system to attempt a command such as
+`systemctl --user status container-cache.service` for the
+webserver or `systemctl --user status container-registry.service`
+for the mirrored registry, you may get an error such as:
+
+----
+[kni@provisioner ~]$ systemctl --user status container-cache
+Failed to connect to bus: No such file or directory
+----
+
+What the following error is trying to address is that the 
+parameter, `DBUS_SESSIONBUS_ADDRESS`, is not set. 
+
+In order to set this variable, we can `export` as follows:
+
+----
+export DBUS_SESSIONBUS_ADDRESS="unix:path/run/user/$id/bus"
+----
+
+Once that has been set, if you re-attempt the `systemctl` command, you should
+see output as follows:
+
+----
+[kni@provisioner ~]$ systemctl --user status container-cache.service
+● container-cache.service - Podman container-cache.service
+   Loaded: loaded (/home/kni/.config/systemd/user/container-cache.service; enabled; vendor preset: enabled)
+   Active: active (running) since Mon 2020-06-01 19:52:04 UTC; 49min ago
+  Process: 36380 ExecStart=/usr/bin/podman start rhcos_image_cache (code=exited, status=0/SUCCESS)
+ Main PID: 36410 (conmon)
+----
+

--- a/documentation/ansible-playbook/modules/ansible-playbook-gotchas.adoc
+++ b/documentation/ansible-playbook/modules/ansible-playbook-gotchas.adoc
@@ -4,3 +4,4 @@
 
 include::ansible-playbook-using-become-yes-within-ansiblecfg-or-inside-playbookyml.adoc[leveloffset=+1]
 include::ansible-playbook-failed-to-install-python3-crypto-python3-pyghmi.adoc[leveloffset=+1]
+include::ansible-playbook-failed-to-connect-to-bus-no-file-or-directory.adoc[leveloffset=+1]


### PR DESCRIPTION
# Description

Currently, if the provisioner or registry host are rebooted, the containers associated with caching and/or registry won't start automatically. This PR should allow for both containers to start upon a reboot. 

Fixes #334 

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
