### PR TITLE
Providing better breakdown of options of IPv4 or IPv6 for provisioning network

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-nmcli-setup-4.3.adoc
+++ b/documentation/ipi-install/modules/ipi-install-nmcli-setup-4.3.adoc
@@ -31,6 +31,8 @@ This step can also be run from the web console.
 +
 [NOTE]
 ====
-The `ssh` connection may disconnect after executing this step.
+The `ssh` connection may disconnect after executing this step. You will want to have some sort
+of out-of-band connection to your host (eg., a serial console, local keyboard, or dedicated 
+management interface) in the event that something goes wrong while executing these commands.
 ====
 +

--- a/documentation/ipi-install/modules/ipi-install-nmcli-setup.adoc
+++ b/documentation/ipi-install/modules/ipi-install-nmcli-setup.adoc
@@ -1,8 +1,10 @@
-. Configure networking.
+. Configure network bridges for both `provisioning` and `baremetal` networks.
 +
 [NOTE]
 ====
-This step can also be run from the web console.
+The `provisioning` bridge can be setup using an IPv4 address or an IPv6 address.
+Either option is supported and the selection should be based upon your
+environmental requirements. 
 ====
 +
 [source,bash]
@@ -21,6 +23,35 @@ This step can also be run from the web console.
     nmcli con down baremetal
     nmcli con up baremetal
 '
+----
++
+[NOTE]
+====
+The `ssh` connection may disconnect after executing this step. You will want to have some sort
+of out-of-band connection to your host (eg., a serial console, local keyboard, or dedicated
+management interface) in the event that something goes wrong while executing these commands.
+====
++
+.Provisioning Network (IPv4 address)
+----
+[kni@provisioner ~]$ sudo nohup bash -c '
+    nmcli con down "$PROV_CONN"
+    nmcli con delete "$PROV_CONN"
+    # RHEL 8.1 appends the word "System" in front of the connection, delete in case it exists
+    nmcli con down "System $PROV_CONN"
+    nmcli con delete "System $PROV_CONN"
+    nmcli connection add ifname provisioning type bridge con-name provisioning
+    nmcli con add type bridge-slave ifname "$PROV_CONN" master provisioning
+    nmcli connection modify provisioning ipv4.addresses 172.22.0.1/24 ipv4.method manual
+    nmcli con down provisioning
+    nmcli con up provisioning
+'
+----
++
+NOTE: The IPv4 address may be any address as long as it is not routable via the `baremetal` network.
++
+.Provisioning Network (IPv6 address)
+----
 [kni@provisioner ~]$ sudo nohup bash -c '
     nmcli con down "$PROV_CONN"
     nmcli con delete "$PROV_CONN"
@@ -35,12 +66,10 @@ This step can also be run from the web console.
 '
 ----
 +
-[NOTE]
+NOTE: The IPv6 address may be any address as long as it is not routable via the `baremetal` network.
++
+[WARNING]
 ====
-The `ssh` connection may disconnect after executing this step. You will want to have some sort of out-of-band connection to your host (eg., a serial console, local keyboard, or dedicated management interface) in the event that something goes wrong while executing these commands.
-
-The IPv6 address may be any address as long as it is not routable via the `baremetal` network.
-
 Ensure that UEFI is enabled and UEFI PXE settings are set to the IPv6 protocol when using IPv6 addressing.
 ====
 +


### PR DESCRIPTION
# Description

After discussions with colleagues, it was concluded that IPv4 should be the default for provisioning network but we should include details on how to setup IPv6. I broke up the procedure into multiple steps to give user options. 


Preview at: https://deploy-preview-409--baremetal-deploy.netlify.app/4.4/deployment

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
