### PR TITLE
Add gulp generator support for docs with spaces

### DIFF
--- a/utils/build-gulp.sh
+++ b/utils/build-gulp.sh
@@ -4,10 +4,14 @@
 sh utils/build.sh
 
 myreleases=$(cat website/_data/releases.yml | grep release | cut -d ":" -f 2- | sort -u -r)
-mydocs=$(cat website/_data/releases.yml | grep name | cut -d ":" -f 2- | sort -u)
+
+declare -a mydocs
+readarray -t mydocs <<<$(cat website/_data/releases.yml | grep name | cut -d ":" -f 2- | sort -u)
 
 mystaticreleases=$(cat website/_data/static.yml | grep release | cut -d ":" -f 2- | sort -u -r)
-mystaticdocs=$(cat website/_data/static.yml | grep name | cut -d ":" -f 2- | sort -u)
+
+declare -a mystaticdocs
+readarray -t mystaticdocs <<<$(cat website/_data/static.yml | grep name | cut -d ":" -f 2- | sort -u)
 
 # Empty index
 >website/index.html
@@ -15,7 +19,7 @@ mystaticdocs=$(cat website/_data/static.yml | grep name | cut -d ":" -f 2- | sor
 # Versioned documents
 echo "<ul>" >>website/index.html
 for release in ${myreleases}; do
-    for doc in ${mydocs}; do
+    for doc in "${mydocs[@]}"; do
         echo "<li><a href=\"${release}/${doc}\">${release}-${doc}</a></li>" >>website/index.html
     done
 done
@@ -25,7 +29,8 @@ echo "</ul>" >>website/index.html
 # Static documents
 echo "<ul>" >>website/index.html
 for release in ${mystaticreleases}; do
-    for doc in ${mystaticdocs}; do
+    for doc in "${mystaticdocs[@]}"; do
+        doc=$(echo "${doc}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
         echo "<li><a href=\"${release}/${doc}\">${release}-${doc}</a></li>" >>website/index.html
     done
 done


### PR DESCRIPTION
# Description

Gulp script failed when generating website index for local development when the documentation started to have 'blanks' in the name

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
