### PR TITLE
Make DNSVip deprecated

### DIFF
--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -99,7 +99,8 @@ cluster=""
 # The public CIDR address, i.e. 10.1.1.0/21
 extcidrnet=""
 # An IP reserved on the baremetal network.
-dnsvip=""
+# Deprecated in OpenShift 4.5 (https://github.com/openshift/installer/pull/3304)
+#dnsvip=""
 # An IP reserved on the baremetal network for the API endpoint.
 # (Optional) If not set, a DNS lookup verifies that api.<clustername>.<domain> provides an IP
 #apivip=""

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -30,7 +30,9 @@ platform:
   baremetal:
     apiVIP: {{ apivip }}
     ingressVIP: {{ ingressvip }}
+    {% if ((release_version[0]|int == 4) and (release_version[2]|int < 5)) %}
     dnsVIP: {{ dnsvip }}
+    {% endif %}
     provisioningBridge: {{ provisioning_bridge }}
 {% if baremetal_bridge != 'baremetal' %}
     externalBridge: {{ baremetal_bridge }}

--- a/documentation/ipi-install/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/documentation/ipi-install/modules/ipi-install-additional-install-config-parameters.adoc
@@ -22,11 +22,13 @@ This setting must either be provided or pre-configured in DNS so that the
 default name resolve correctly.
 | `ingressVIP` | `test.apps.<clusterdomain>` | The VIP to use for ingress traffic.
 
+ifeval::[{release} < 4.5]
 This setting must either be provided or pre-configured in DNS so that the
 default name resolve correctly.
 |`dnsVIP` | | The VIP to use for internal DNS communication.
 
 This setting has no default and must always be provided.
+endif::[]
 |===
 
 .Hosts

--- a/documentation/ipi-install/modules/ipi-install-config-yaml-4.4.adoc
+++ b/documentation/ipi-install/modules/ipi-install-config-yaml-4.4.adoc
@@ -21,6 +21,7 @@ platform:
   baremetal:
     apiVIP: <api-ip>
     ingressVIP: <wildcard-ip>
+    dnsVIP: <dns-ip>
     provisioningNetworkInterface: <NIC1>
     provisioningNetworkCIDR: <CIDR> # i.e. fd00:1101::1/64
     provisioningBridge: provisioning

--- a/documentation/ipi-install/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/documentation/ipi-install/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -9,11 +9,17 @@
 The `install-config.yaml` file requires some additional details.
 Most of the information is teaching the installer and the resulting cluster enough about the available hardware so that it is able to fully manage it.
 
-ifeval::[{release} > 4.3]
+ifeval::[{release} > 4.4]
 include::ipi-install-config-yaml.adoc[leveloffset=0]
+endif::[]
+
+ifeval::[{release} <= 4.4]
+ifeval::[{release} > 4.3]
+include::ipi-install-config-yaml-4.4.adoc[leveloffset=0]
 endif::[]
 ifeval::[{release} <= 4.3]
 include::ipi-install-config-yaml-4.3.adoc[leveloffset=0]
+endif::[]
 endif::[]
 
 . Create a directory to store cluster configs.

--- a/documentation/ipi-install/modules/ipi-ipv6-install-config-yaml-4.5.adoc
+++ b/documentation/ipi-install/modules/ipi-ipv6-install-config-yaml-4.5.adoc
@@ -6,7 +6,7 @@ apiVersion: v1
 baseDomain: <domain>
 networking:
   networkType: OVNKubernetes
-  machineCIDR: <IPv6-baremetal-public-cidr> #e.g:2620:52:0:1302::/64 
+  machineCIDR: <IPv6-baremetal-public-cidr> #e.g:2620:52:0:1302::/64
   clusterNetwork:
   - cidr: fd01::/48
     hostPrefix: 64
@@ -31,9 +31,8 @@ platform:
     bootstrapOSImage: "<rhcos-boostrap-image-cache-url>" #e.g: http://[2620:52:0:1307::1]/rhcos-44.81.202004250133-0-qemu.x86_64.qcow2.gz?sha256=7d884b46ee54fe87bbc3893bf2aa99af3b2d31f2e19ab5529c60636fbd0f1ce7
     clusterOSImage: "rhcos-node-image-cache-url>" #e.g: http://[2620:52:0:1307::1]/rhcos-44.81.202004250133-0-openstack.x86_64.qcow2.gz?sha256=370a5abf8486d2656b38eb596bf4b2103f8d3b1faaca8bfb2f086a16185c2d1b
     provisioningNetworkCIDR: <IPv6-provisioning-cidr> #e.g: 2620:52:0:1307::/64
-    dnsVIP: <dns-ip> #e.g: 2620:52:0:1302::4 
     apiVIP: <api-ip> #e.g: 2620:52:0:1302::3
-    ingressVIP: <wildcard-ip> #e.g: 2620:52:0:1302::2 
+    ingressVIP: <wildcard-ip> #e.g: 2620:52:0:1302::2
     hosts:
       - name: openshift-master-0
         role: master


### PR DESCRIPTION
# Description

Makes DNSVip parameter deprecated for 4.5

Previews:
4.5 without parameter in table: https://deploy-preview-423--baremetal-deploy.netlify.app/4.5/deployment#additional-install-config-parameters_ipi-install-prerequisites
4.4 with parameter in table: https://deploy-preview-423--baremetal-deploy.netlify.app/4.4/deployment#additional-install-config-parameters_ipi-install-prerequisites



Fixes #402 

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
