### PR TITLE
Removed  sudo command as its not necessary

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-creating-the-openshift-manifests.adoc
+++ b/documentation/ipi-install/modules/ipi-install-creating-the-openshift-manifests.adoc
@@ -9,7 +9,7 @@
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ sudo ./openshift-baremetal-install --dir ~/clusterconfigs create manifests
+[kni@provisioner ~]$ ./openshift-baremetal-install --dir ~/clusterconfigs create manifests
 ----
 +
 ----

--- a/documentation/ipi-install/modules/ipi-install-deploying-the-cluster-via-the-openshift-installer.adoc
+++ b/documentation/ipi-install/modules/ipi-install-deploying-the-cluster-via-the-openshift-installer.adoc
@@ -9,5 +9,5 @@ Run the {product-title} installer:
 
 [source,bash]
 ----
-[kni@provisioner ~]$ sudo ./openshift-baremetal-install --dir ~/clusterconfigs --log-level debug create cluster
+[kni@provisioner ~]$ ./openshift-baremetal-install --dir ~/clusterconfigs --log-level debug create cluster
 ----


### PR DESCRIPTION
# Description

There was no need to use `sudo` command while creating the manifests, rectifying this changes in this PR. 

Fixes #435 

## Type of change

- [x] This change requires a documentation update


## Checklist

- [x] I have performed a self-review of my own code
- [x] PRs should not be merged unless positively reviewed.
