### PR TITLE
Adding info for OSImages

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/documentation/ipi-install/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -108,3 +108,5 @@ Use the following steps to install a container that contains the images.
 -p 8080:8080/tcp \
 registry.centos.org/centos/httpd-24-centos7:latest
 ----
+
+. The above command creates a caching webserver with the name `rhcos_image_cache` which will be serving the images for deployment. The first image `${RHCOS_PATH}${RHCOS_QEMU_URI}?sha256=${RHCOS_QEMU_SHA_UNCOMPRESSED}` will be used as `bootstrapOSImage` and the second image `${RHCOS_PATH}${RHCOS_OPENSTACK_URI}?sha256=${RHCOS_OPENSTACK_SHA_COMPRESSED}` will be used as `clusterOSImage` in `install-config.yaml` file as shown in xref:additional-install-config-parameters_{context}[Additional install-config parameters] section. 


### PR DESCRIPTION
# Description

Adding description which shows how the parameters `bootstrapOSImage` and `ClusterOSImage` are used in `install-config.yaml` file. 

Fixes #424 

## Type of change

- [x] This change is a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] PRs should not be merged unless positively reviewed.
