### PR TITLE
Fix description of certificate "C" attribute

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-creating-a-disconnected-registry.adoc
+++ b/documentation/ipi-install/modules/ipi-install-creating-a-disconnected-registry.adoc
@@ -61,7 +61,7 @@ Generate a self-signed certificate for the registry node and put it in the `/opt
 [source,bash]
 ----
 [user@registry ~]$ host_fqdn=$( hostname --long )
-[user@registry ~]$ cert_c="<Common Name>"    # Certificate Common Name (CN)
+[user@registry ~]$ cert_c="<Country Name>"   # Certificate Country Name (C)
 [user@registry ~]$ cert_s="<State>"          # Certificate State (S)
 [user@registry ~]$ cert_l="<Locality>"       # Certificate Locality (L)
 [user@registry ~]$ cert_o="<Organization>"   # Certificate Organization (O)
@@ -79,7 +79,7 @@ Generate a self-signed certificate for the registry node and put it in the `/opt
     -subj "/C=${cert_c}/ST=${cert_s}/L=${cert_l}/O=${cert_o}/OU=${cert_ou}/CN=${cert_cn}"
 ----
 +
-NOTE: When replacing `<Comman Name>`, ensure it only contains two letters. For example, `US`.
+NOTE: When replacing `<Country Name>`, ensure it only contains two letters. For example, `US`.
 
 . Update the registry node's `ca-trust` with the new certificate.
 +


### PR DESCRIPTION
The "C" attribute of an x509 certificate is the *country* name, not
the *common* name.


# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.