### PR TITLE
Adding ability to use root device hints for OCP4.5

### DIFF
--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -126,6 +126,12 @@ extcidrnet=""
 # A copy of your pullsecret from https://cloud.redhat.com/openshift/install/metal/user-provisioned
 pullsecret=""
 
+# (Optional) OpenShift 4.5+, Set Root Device Hints to choose the proper device to install operating system on OpenShift nodes.
+# root device hint options include: ['deviceName','hctl','model','vendor','serialNumber','minSizeGigabytes','wwn','rotational']
+# Root Device Hint values are case sensitive.
+#root_device_hint="deviceName"
+#root_hint_value="/dev/sda"
+
 # Master nodes
 # The hardware_profile is used by the baremetal operator to match the hardware discovered on the host
 # See https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md#baremetalhost-status

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -60,10 +60,16 @@ platform:
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}
         bootMACAddress: {{ hostvars[host]['provision_mac'] }}
+{% if ((release_version[0]|int == 4) and (release_version[2]|int < 5)) %}
 {% if 'hardware_profile' in hostvars[host] %}
         hardwareProfile: {{ hostvars[host]['hardware_profile'] }}
 {% else %}
         hardwareProfile: default
+{% endif %}
+{% endif %}
+{% if ((release_version[0]|int == 4) and (release_version[2]|int >= 5)) and root_device_hint|length %}
+        rootDeviceHints:
+          {{ root_device_hint }}: {{ root_hint_value }}
 {% endif %}
 {% endfor %}
 {% if groups['workers'] is defined %}
@@ -79,10 +85,16 @@ platform:
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}
         bootMACAddress: {{ hostvars[host]['provision_mac'] }}
+{% if ((release_version[0]|int == 4) and (release_version[2]|int < 5)) %}
 {% if 'hardware_profile' in hostvars[host] %}
         hardwareProfile: {{ hostvars[host]['hardware_profile'] }}
 {% else %}
         hardwareProfile: unknown
+{% endif %}
+{% endif %}
+{% if ((release_version[0]|int == 4) and (release_version[2]|int >= 5)) and root_device_hint|length %}
+        rootDeviceHints:
+          {{ root_device_hint }}: {{ root_hint_value }}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/ansible-ipi-install/roles/node-prep/defaults/main.yml
+++ b/ansible-ipi-install/roles/node-prep/defaults/main.yml
@@ -13,3 +13,5 @@ ipv4_provisioning: false
 provisioning_bridge: "provisioning"
 webserver_url: ""
 baremetal_bridge: "baremetal"
+root_device_hint: ""
+root_hint_value: ""

--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -342,3 +342,32 @@
   tags:
   - always
   - validation
+
+- name: Verify if root hint is valid
+  fail:
+    msg: "The supplied root hint {{ root_device_hint }} is invalid. Valid responses: {{ roothint_list }}"
+  when: root_device_hint not in roothint_list
+  tags:
+  - always
+  - validation
+
+- name: Verify root hint value is supplied when root hint is set
+  fail:
+    msg: "Supplied root device hint but no root hint value."
+  when: root_device_hint|length and root_hint_value|length == 0
+  tags:
+  - always
+  - validation
+
+- name: root hint value is supplied but root device hint not set
+  fail:
+    msg: "Supplied root hint value but no root device hint."
+  when: root_device_hint|length == 0 and root_hint_value|length
+  tags:
+  - always
+  - validation
+- name: Get root hint and value
+  debug:
+    msg: "root_device_hint: {{ root_device_hint }} and root_hint_value: {{ root_hint_value }}"
+    verbosity: 2
+  tags: validation

--- a/ansible-ipi-install/roles/node-prep/vars/main.yml
+++ b/ansible-ipi-install/roles/node-prep/vars/main.yml
@@ -31,3 +31,14 @@ qtype: "{{ ((ipv6_enabled|bool and ipv4_baremetal|bool) or (not ipv6_enabled|boo
 drm_set: false
 dra_set: false
 registry_host_exists: false
+
+roothint_list:
+  - deviceName
+  - hctl
+  - model
+  - vendor
+  - serialNumber
+  - minSizeGigabytes
+  - wwn
+  - rotational
+  - ''

--- a/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
+++ b/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
@@ -134,6 +134,12 @@ dnsvip=""
 # A copy of your pullsecret from https://cloud.redhat.com/openshift/install/metal/user-provisioned
 pullsecret=""
 
+# (Optional) OpenShift 4.5+, Set Root Device Hints to choose the proper device to install operating system on OpenShift nodes.
+# root device hint options include: ['deviceName','hctl','model','vendor','serialNumber','minSizeGigabytes','wwn','rotational']
+# Root Device Hint values are case sensitive.
+#root_device_hint="deviceName"
+#root_hint_value="/dev/sda"
+
 # Master nodes
 # The hardware_profile is used by the baremetal operator to match the hardware discovered on the host
 # See https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md#baremetalhost-status


### PR DESCRIPTION
# Description

Adding the ability to provide a root device hint for OCP4.5, so it may select the appropriate root disk to install the OS. 

Example on how to enable, within your inventory/hosts file. 
```
# (Optional) OpenShift 4.5+, Set Root Device Hints to choose the proper device to install operating system on OpenShift nodes.
# root device hint options include: ['deviceName','hctl','model','vendor','serialNumber','minSizeGigabytes','wwn','rotational']
# Root Device Hint values are case sensitive.
#root_device_hint="deviceName"
#root_hint_value="/dev/sda"
```

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



## Checklist

- [x] I have performed a self-review of my own code
- [x] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
