### PR TITLE
Ensuring that dnsVIP parameter only fails when empty if OCP4.4 or lower

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -49,7 +49,7 @@
 - name: Fail if a required install-config variable is undefined or empty.
   fail:
     msg: "A variable regarding install-config.yml is undefined or empty."
-  when: (domain is undefined) or (domain|length == 0) or (cluster is undefined) or (cluster|length == 0) or (extcidrnet is undefined) or (extcidrnet|length == 0) or (dnsvip is undefined) or (dnsvip|length == 0) or (pullsecret is undefined) or (pullsecret|length == 0)
+  when: (domain is undefined) or (domain|length == 0) or (cluster is undefined) or (cluster|length == 0) or (extcidrnet is undefined) or (extcidrnet|length == 0) or (pullsecret is undefined) or (pullsecret|length == 0)
   tags:
   - always
   - validation
@@ -329,6 +329,16 @@
   set_fact:
     masters_prov_nic: "{{ prov_nic }}"
   when: (masters_prov_nic is undefined) or (masters_prov_nic|length == 0)
+  tags:
+  - always
+  - validation
+
+- name: Fail if DNSVIP not set (OCP 4.4 or lower)
+  fail:
+    msg: "dnsvip variable is undefined or empty."
+  when: 
+  - ((release_version[0]|int == 4) and (release_version[2]|int < 5))
+  - ((dnsvip is undefined) or (dnsvip|length == 0))
   tags:
   - always
   - validation


### PR DESCRIPTION
# Description

Currently dnsVIP parameter if empty was failing on OCP4.5 even though it is no longer a requirement. 

Fixes #474 

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
