### PR TITLE
Remove root device hints for 4.5 and earlier

### DIFF
--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -126,7 +126,7 @@ extcidrnet=""
 # A copy of your pullsecret from https://cloud.redhat.com/openshift/install/metal/user-provisioned
 pullsecret=""
 
-# (Optional) OpenShift 4.5+, Set Root Device Hints to choose the proper device to install operating system on OpenShift nodes.
+# (Optional) OpenShift 4.6+, Set Root Device Hints to choose the proper device to install operating system on OpenShift nodes.
 # root device hint options include: ['deviceName','hctl','model','vendor','serialNumber','minSizeGigabytes','wwn','rotational']
 # Root Device Hint values are case sensitive.
 #root_device_hint="deviceName"

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -60,14 +60,14 @@ platform:
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}
         bootMACAddress: {{ hostvars[host]['provision_mac'] }}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int < 5)) %}
+{% if ((release_version[0]|int == 4) and (release_version[2]|int < 6)) %}
 {% if 'hardware_profile' in hostvars[host] %}
         hardwareProfile: {{ hostvars[host]['hardware_profile'] }}
 {% else %}
         hardwareProfile: default
 {% endif %}
 {% endif %}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int >= 5)) and root_device_hint|length %}
+{% if ((release_version[0]|int == 4) and (release_version[2]|int >= 6)) and root_device_hint|length %}
         rootDeviceHints:
           {{ root_device_hint }}: {{ root_hint_value }}
 {% endif %}
@@ -85,14 +85,14 @@ platform:
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}
         bootMACAddress: {{ hostvars[host]['provision_mac'] }}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int < 5)) %}
+{% if ((release_version[0]|int == 4) and (release_version[2]|int < 6)) %}
 {% if 'hardware_profile' in hostvars[host] %}
         hardwareProfile: {{ hostvars[host]['hardware_profile'] }}
 {% else %}
         hardwareProfile: unknown
 {% endif %}
 {% endif %}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int >= 5)) and root_device_hint|length %}
+{% if ((release_version[0]|int == 4) and (release_version[2]|int >= 6)) and root_device_hint|length %}
         rootDeviceHints:
           {{ root_device_hint }}: {{ root_hint_value }}
 {% endif %}

--- a/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
+++ b/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
@@ -134,7 +134,7 @@ dnsvip=""
 # A copy of your pullsecret from https://cloud.redhat.com/openshift/install/metal/user-provisioned
 pullsecret=""
 
-# (Optional) OpenShift 4.5+, Set Root Device Hints to choose the proper device to install operating system on OpenShift nodes.
+# (Optional) OpenShift 4.6+, Set Root Device Hints to choose the proper device to install operating system on OpenShift nodes.
 # root device hint options include: ['deviceName','hctl','model','vendor','serialNumber','minSizeGigabytes','wwn','rotational']
 # Root Device Hint values are case sensitive.
 #root_device_hint="deviceName"


### PR DESCRIPTION
# Description

Removes Ansible installer support for root device hints for 4.5 and earlier.

Fixes # 476

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Before applying patch: Deploy 4.5 with the Ansible installer, targeting VMs as masters and workers.  Set appropriate host vars to include root device hint to set `deviceName` to `/dev/vda`.  The installation should fail, with the bootstrap's Ironic inspector complaining that it could not find a disk match.
- [x] After applying patch: Deploy 4.5 with the Ansible installer, targeting VMs as masters and workers.  Set appropriate host vars to include `hardwareProfile` set to `libvirt`.  The installation should provision the masters and workers just fine, without Ironic complaining about disk mismatches.

**Test Configuration**:

- Versions: OCP 4.5
- Hardware: 5 Libvirt VMs

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
