### PR TITLE
Intelligently decide between using IPMI or RedFish protocol based on Vendor and Firmware version

### DIFF
--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -132,6 +132,10 @@ pullsecret=""
 #root_device_hint="deviceName"
 #root_hint_value="/dev/sda"
 
+# (Optional) Disable BMC Certification Validation. When using self-signed certificates for your BMC, ensure to set to True.
+# Default value is False. 
+#disable_bmc_certificate_verification=True
+
 # Master nodes
 # The hardware_profile is used by the baremetal operator to match the hardware discovered on the host
 # See https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md#baremetalhost-status

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -52,10 +52,14 @@ platform:
       - name: {{ hostvars[host]['inventory_hostname'] }}
         role: {{ hostvars[host]['role'] }}
         bmc:
-{% if 'ipmi_port' in hostvars[host] %}
-          address: ipmi://{{ hostvars[host]['ipmi_address']|ipwrap }}:{{ hostvars[host]['ipmi_port'] }}
+{% if groups['dell_hosts_redfish'] is defined and host in groups['dell_hosts_redfish'] and ((release_version[0]|int > 4) or ((release_version[0]|int == 4) and (release_version[2]|int >= 5))) %}
+          address: redfish://{{ hostvars[host]['ipmi_address']|ipwrap }}/redfish/v1/Systems/System.Embedded.1
+          disableCertificateVerification: {{ disable_bmc_certificate_verification }}
+{% elif groups['hp_hosts_redfish'] is defined and host in groups['hp_hosts_redfish'] and ((release_version[0]|int > 4) or ((release_version[0]|int == 4) and (release_version[2]|int >= 5))) %}
+          address: redfish://{{ hostvars[host]['ipmi_address']|ipwrap }}/redfish/v1/Systems/1
+          disableCertificateVerification: {{ disable_bmc_certificate_verification }}
 {% else %}
-          address: ipmi://{{ hostvars[host]['ipmi_address']|ipwrap }}
+          address: ipmi://{{ hostvars[host]['ipmi_address']|ipwrap }}:{{ hostvars[host]['ipmi_port']|default(623) }}
 {% endif %}
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}
@@ -77,10 +81,14 @@ platform:
       - name: {{ hostvars[host]['inventory_hostname'] }}
         role: {{ hostvars[host]['role'] }}
         bmc:
-{% if 'ipmi_port' in hostvars[host] %}
-          address: ipmi://{{ hostvars[host]['ipmi_address']|ipwrap }}:{{ hostvars[host]['ipmi_port'] }}
+{% if groups['dell_hosts_redfish'] is defined and host in groups['dell_hosts_redfish'] %}
+          address: redfish://{{ hostvars[host]['ipmi_address']|ipwrap }}/redfish/v1/Systems/System.Embedded.1
+          disableCertificateVerification: {{ disable_bmc_certificate_verification }}
+{% elif groups['hp_hosts_redfish'] is defined and host in groups['hp_hosts_redfish'] %}
+          address: redfish://{{ hostvars[host]['ipmi_address']|ipwrap }}/redfish/v1/Systems/1
+          disableCertificateVerification: {{ disable_bmc_certificate_verification }}
 {% else %}
-          address: ipmi://{{ hostvars[host]['ipmi_address']|ipwrap }}
+          address: ipmi://{{ hostvars[host]['ipmi_address']|ipwrap }}:{{ hostvars[host]['ipmi_port']|default(623) }}
 {% endif %}
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}

--- a/ansible-ipi-install/roles/node-prep/defaults/main.yml
+++ b/ansible-ipi-install/roles/node-prep/defaults/main.yml
@@ -15,3 +15,4 @@ webserver_url: ""
 baremetal_bridge: "baremetal"
 root_device_hint: ""
 root_hint_value: ""
+disable_bmc_certificate_verification: false

--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -371,3 +371,58 @@
     msg: "root_device_hint: {{ root_device_hint }} and root_hint_value: {{ root_hint_value }}"
     verbosity: 2
   tags: validation
+
+- name: Get all the chassis results from all the hosts
+  redfish_info:
+    category: Chassis
+    command: GetChassisInventory
+    baseuri: "{{ hostvars[item]['ipmi_address'] }}"
+    username: "{{ hostvars[item]['ipmi_user'] }}"
+    password: "{{ hostvars[item]['ipmi_password'] }}"
+  register: chassis_result
+  with_items:
+  - "{{ groups.masters }}"
+  - "{{ groups.workers | default([]) }}"
+  ignore_errors: yes
+  tags: validation
+
+- name: Get all the firmware results from all the hosts
+  redfish_info:
+    category: Update
+    command: GetFirmwareInventory
+    baseuri: "{{ hostvars[item]['ipmi_address'] }}"
+    username: "{{ hostvars[item]['ipmi_user'] }}"
+    password: "{{ hostvars[item]['ipmi_password'] }}"
+  register: firmware_result
+  with_items:
+  - "{{ groups.masters }}"
+  - "{{ groups.workers | default([]) }}"
+  ignore_errors: yes
+  tags: validation
+
+- name: Add all the hosts that are Dell to a group with iDRAC firmware higher than 4.20.20.20
+  add_host:
+    groups: dell_hosts_redfish
+    hostname: "{{ chassis_result.results[item|int].item }}"
+  with_sequence: start=0 end="{{ numworkers|int + nummasters|int - 1 }}"
+  when:
+    - not chassis_result.results[{{ item }}].failed|bool
+    - not firmware_result.results[{{ item }}].failed|bool
+    - "'Dell' in chassis_result.results[{{ item }}].redfish_facts.chassis.entries[0].Manufacturer"
+    - firmware_result.results[{{ item }}].redfish_facts.firmware.entries | json_query(query) | max >= "4.20.20.20"
+  vars:
+    query: "[?Name=='Integrated Dell Remote Access Controller'].Version"
+  register: dell_host_redfish_result
+  tags: validation
+
+- name: Add all the hosts that are HP to a group
+  add_host:
+    groups: hp_hosts_redfish
+    hostname: "{{ chassis_result.results[item|int].item }}"
+  with_sequence: start=0 end="{{ numworkers|int + nummasters|int - 1 }}"
+  when:
+    - not chassis_result.results[{{ item }}].failed|bool
+    - not firmware_result.results[{{ item }}].failed|bool
+    - "'HPE' in chassis_result.results[{{ item }}].redfish_facts.chassis.entries[0].Manufacturer"
+  register: hp_host_redfish_result
+  tags: validation

--- a/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
+++ b/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
@@ -140,6 +140,10 @@ pullsecret=""
 #root_device_hint="deviceName"
 #root_hint_value="/dev/sda"
 
+# (Optional) Disable BMC Certification Validation. When using self-signed certificates for your BMC, ensure to set to True.
+# Default value is False. 
+#disable_bmc_certificate_verification=True
+
 # Master nodes
 # The hardware_profile is used by the baremetal operator to match the hardware discovered on the host
 # See https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md#baremetalhost-status


### PR DESCRIPTION
# Description

Currently the Ansible playbook only allows for the use of IPMI protocol. This PR now contains logic to successfully decide if a particular host should use IPMI or RedFish as its protocol.

The logic is as follows:
* Dell server with iDRAC firmware version 4.20.20.20 or higher use RedFish 
* HPE server use RedFish 
* All other systems, or Dell systems that do not have a firmware of 4.20.20.20 or higher default to IPMI.

This patch will look at each server individually and make the appropriate decision thus removing the need for a user to know if their particular server and firmware can support RedFish. If it can, it will.  

In addition, there is now a `bmc_certificate_verification` variable that allows you to set to True if your RedFish certificates are self-signed. The default value is False. 

Fixes #134 

## Type of change

Please select the appropiate options:

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
