### PR TITLE
Adding multiple retries and a delay when attempting to gather redfish facts for HPE and Dell servers

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -413,6 +413,8 @@
   vars:
     query: "[?Name=='Integrated Dell Remote Access Controller'].Version"
   register: dell_host_redfish_result
+  retries: 6 # 1 minute (10 * 6)
+  delay: 10 # Every 10 seconds
   tags: validation
 
 - name: Add all the hosts that are HP to a group
@@ -425,4 +427,6 @@
     - not firmware_result.results[{{ item }}].failed|bool
     - "'HPE' in chassis_result.results[{{ item }}].redfish_facts.chassis.entries[0].Manufacturer"
   register: hp_host_redfish_result
+  retries: 6 # 1 minute (10 * 6)
+  delay: 10 # Every 10 seconds
   tags: validation


### PR DESCRIPTION

# Description

Currently the playbook intermittent fails with the following error. Adding some retries and a small delay in order to overcome these intermittent failures. 

```
TASK [node-prep : Add all the hosts that are Dell to a group with iDRAC firmware higher than 4.20.20.20] ***
Monday 17 August 2020  19:21:12 +0000 (0:06:40.958)       0:08:00.773 ********* 
[WARNING]: conditional statements should not include jinja2 templating
delimiters such as {{ }} or {% %}. Found: not chassis_result.results[{{ item
}}].failed|bool
[WARNING]: conditional statements should not include jinja2 templating
delimiters such as {{ }} or {% %}. Found: not firmware_result.results[{{ item
}}].failed|bool
[WARNING]: conditional statements should not include jinja2 templating
delimiters such as {{ }} or {% %}. Found: 'Dell' in chassis_result.results[{{
item }}].redfish_facts.chassis.entries[0].Manufacturer
[WARNING]: conditional statements should not include jinja2 templating
delimiters such as {{ }} or {% %}. Found: firmware_result.results[{{ item
}}].redfish_facts.firmware.entries | json_query(query) | max >= "4.20.20.20"
fatal: [kni3-deployhost.kni3.cloud.lab.eng.bos.redhat.com]: FAILED! => {"msg": "The conditional check 'firmware_result.results[{{ item }}].redfish_facts.firmware.entries | json_query(query) | max >= \"4.20.20.20\"' failed. The error was: Unexpected templating type error occurred on ({% if firmware_result.results[0].redfish_facts.firmware.entries | json_query(query) | max >= \"4.20.20.20\" %} True {% else %} False {% endif %}): 'NoneType' object is not iterable\n\nThe error appears to be in '/home/jenkins/baremetal-deploy/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml': line 403, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Add all the hosts that are Dell to a group with iDRAC firmware higher than 4.20.20.20\n  ^ here\n"}
```

Fixes #498 

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
