### PR TITLE
Ignore errors on the add host tasks, if there is an error, defaults to IPMI

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -415,6 +415,7 @@
   register: dell_host_redfish_result
   retries: 6 # 1 minute (10 * 6)
   delay: 10 # Every 10 seconds
+  ignore_errors: yes
   tags: validation
 
 - name: Add all the hosts that are HP to a group
@@ -429,4 +430,5 @@
   register: hp_host_redfish_result
   retries: 6 # 1 minute (10 * 6)
   delay: 10 # Every 10 seconds
+  ignore_errors: yes
   tags: validation


### PR DESCRIPTION


# Description

Some older iDRACs from dell give a timeout error. For now, the workaround is going to be that if one of your systems in the inventory has a timeout, all your inventory will use IPMI. 

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
