### PR TITLE
Fixing root device hints, making it a per entry of host in inventory

### DIFF
--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -126,12 +126,6 @@ extcidrnet=""
 # A copy of your pullsecret from https://cloud.redhat.com/openshift/install/metal/user-provisioned
 pullsecret=""
 
-# (Optional) OpenShift 4.6+, Set Root Device Hints to choose the proper device to install operating system on OpenShift nodes.
-# root device hint options include: ['deviceName','hctl','model','vendor','serialNumber','minSizeGigabytes','wwn','rotational']
-# Root Device Hint values are case sensitive.
-#root_device_hint="deviceName"
-#root_hint_value="/dev/sda"
-
 # (Optional) Disable BMC Certification Validation. When using self-signed certificates for your BMC, ensure to set to True.
 # Default value is False. 
 #disable_bmc_certificate_verification=True
@@ -142,6 +136,12 @@ pullsecret=""
 # ipmi_port is optional for each host. 623 is the common default used if omitted
 # poweroff is optional. True or ommited (by default) indicates the playbook will power off the node before deploying OCP
 #  otherwise set it to false
+# (Optional) OpenShift 4.6+, Set Root Device Hints to choose the proper device to install operating system on OpenShift nodes.
+# root device hint options include: ['deviceName','hctl','model','vendor','serialNumber','minSizeGigabytes','wwn','rotational']
+# Root Device Hint values are case sensitive. If incorrect case given, entry omitted from install-config.yaml
+# root_device_hint="deviceName"
+# root_device_hint_value="/dev/sda"
+
 [masters]
 master-0 name=master-0 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.1 ipmi_port=623 provision_mac=ec:f4:bb:da:0c:58 hardware_profile=default poweroff=true
 master-1 name=master-1 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.2 ipmi_port=623 provision_mac=ec:f4:bb:da:32:88 hardware_profile=default poweroff=true

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -71,9 +71,11 @@ platform:
         hardwareProfile: default
 {% endif %}
 {% endif %}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int >= 6)) and root_device_hint|length %}
+{% if ((release_version[0]|int == 4) and (release_version[2]|int >= 6)) %}
+{% if 'root_device_hint' in hostvars[host] and 'root_device_hint_value' in hostvars[host] and hostvars[host]['root_device_hint'] in roothint_list %}
         rootDeviceHints:
-          {{ root_device_hint }}: {{ root_hint_value }}
+          {{ hostvars[host]['root_device_hint'] }}: {{ hostvars[host]['root_device_hint_value'] }}
+{% endif %}
 {% endif %}
 {% endfor %}
 {% if groups['workers'] is defined %}
@@ -100,9 +102,11 @@ platform:
         hardwareProfile: unknown
 {% endif %}
 {% endif %}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int >= 6)) and root_device_hint|length %}
+{% if ((release_version[0]|int == 4) and (release_version[2]|int >= 6)) %}
+{% if 'root_device_hint' in hostvars[host] and 'root_device_hint_value' in hostvars[host] %}
         rootDeviceHints:
-          {{ root_device_hint }}: {{ root_hint_value }}
+          {{ hostvars[host]['root_device_hint'] }}: {{ hostvars[host]['root_device_hint_value'] }}
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/ansible-ipi-install/roles/node-prep/defaults/main.yml
+++ b/ansible-ipi-install/roles/node-prep/defaults/main.yml
@@ -13,6 +13,4 @@ ipv4_provisioning: false
 provisioning_bridge: "provisioning"
 webserver_url: ""
 baremetal_bridge: "baremetal"
-root_device_hint: ""
-root_hint_value: ""
 disable_bmc_certificate_verification: false

--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -20,7 +20,6 @@
   - always
   - validation
 
-
 - name: Fail if Python modules are missing
   fail:
     msg: |
@@ -342,35 +341,6 @@
   tags:
   - always
   - validation
-
-- name: Verify if root hint is valid
-  fail:
-    msg: "The supplied root hint {{ root_device_hint }} is invalid. Valid responses: {{ roothint_list }}"
-  when: root_device_hint not in roothint_list
-  tags:
-  - always
-  - validation
-
-- name: Verify root hint value is supplied when root hint is set
-  fail:
-    msg: "Supplied root device hint but no root hint value."
-  when: root_device_hint|length and root_hint_value|length == 0
-  tags:
-  - always
-  - validation
-
-- name: root hint value is supplied but root device hint not set
-  fail:
-    msg: "Supplied root hint value but no root device hint."
-  when: root_device_hint|length == 0 and root_hint_value|length
-  tags:
-  - always
-  - validation
-- name: Get root hint and value
-  debug:
-    msg: "root_device_hint: {{ root_device_hint }} and root_hint_value: {{ root_hint_value }}"
-    verbosity: 2
-  tags: validation
 
 - name: Get all the chassis results from all the hosts
   redfish_info:

--- a/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
+++ b/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
@@ -134,12 +134,6 @@ dnsvip=""
 # A copy of your pullsecret from https://cloud.redhat.com/openshift/install/metal/user-provisioned
 pullsecret=""
 
-# (Optional) OpenShift 4.6+, Set Root Device Hints to choose the proper device to install operating system on OpenShift nodes.
-# root device hint options include: ['deviceName','hctl','model','vendor','serialNumber','minSizeGigabytes','wwn','rotational']
-# Root Device Hint values are case sensitive.
-#root_device_hint="deviceName"
-#root_hint_value="/dev/sda"
-
 # (Optional) Disable BMC Certification Validation. When using self-signed certificates for your BMC, ensure to set to True.
 # Default value is False. 
 #disable_bmc_certificate_verification=True
@@ -150,6 +144,12 @@ pullsecret=""
 # ipmi_port is optional for each host. 623 is the common default used if omitted
 # poweroff is optional. True or ommited (by default) indicates the playbook will power off the node before deploying OCP
 #  otherwise set it to false
+# (Optional) OpenShift 4.6+, Set Root Device Hints to choose the proper device to install operating system on OpenShift nodes.
+# root device hint options include: ['deviceName','hctl','model','vendor','serialNumber','minSizeGigabytes','wwn','rotational']
+# Root Device Hint values are case sensitive.
+# root_device_hint="deviceName"
+# root_device_hint_value="/dev/sda"
+
 [masters]
 master-0 name=master-0 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.1 ipmi_port=623 provision_mac=ec:f4:bb:da:0c:58 hardware_profile=default poweroff=true
 master-1 name=master-1 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.2 ipmi_port=623 provision_mac=ec:f4:bb:da:32:88 hardware_profile=default poweroff=true


### PR DESCRIPTION
# Description

Currently, the playbook sets device hints globally across all nodes. However, this will not work as all nodes need to have an individual entry. This PR fixes that. 

Fixes # (issue)

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
