### PR TITLE
Add retries to task that gets chassis results

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -350,6 +350,9 @@
     username: "{{ hostvars[item]['ipmi_user'] }}"
     password: "{{ hostvars[item]['ipmi_password'] }}"
   register: chassis_result
+  until: chassis_result is succeeded
+  retries: 3
+  delay: 10
   with_items:
   - "{{ groups.masters }}"
   - "{{ groups.workers | default([]) }}"


### PR DESCRIPTION
Sometimes, the task to fetch chassis results, fails on some hosts
intermittently. This results in ipmi:// being used in install-config.yaml
even for hosts that have firmware that supports redfish. This commits adds
a few retries to overcome the issue in cases of flaky responses from the hosts.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

# Description
Sometimes although the host in general supports redifsh, the call to get chassis results intermittently fails, which leads to the issue of perfectly fine redfish compatible hosts being forced to use ipmi. This solves the flaky redfish response issue.
Example:
```
TASK [node-prep : Get all the chassis results from all the hosts] ****************************************************************************************************************************************************************************
Thursday 27 August 2020  19:48:31 -0400 (0:00:00.065)       0:02:19.726 ******* 
ok: [e16-h12-b01-fc640.rdu2.scalelab.redhat.com] => (item=master-0)
ok: [e16-h12-b01-fc640.rdu2.scalelab.redhat.com] => (item=master-1)
ok: [e16-h12-b01-fc640.rdu2.scalelab.redhat.com] => (item=master-2)
FAILED - RETRYING: Get all the chassis results from all the hosts (3 retries left).
ok: [e16-h12-b01-fc640.rdu2.scalelab.redhat.com] => (item=worker-0)
ok: [e16-h12-b01-fc640.rdu2.scalelab.redhat.com] => (item=worker-1)
ok: [e16-h12-b01-fc640.rdu2.scalelab.redhat.com] => (item=worker-2)
ok: [e16-h12-b01-fc640.rdu2.scalelab.redhat.com] => (item=worker-3)
FAILED - RETRYING: Get all the chassis results from all the hosts (3 retries left).
FAILED - RETRYING: Get all the chassis results from all the hosts (2 retries left).
FAILED - RETRYING: Get all the chassis results from all the hosts (1 retries left).
failed: [e16-h12-b01-fc640.rdu2.scalelab.redhat.com] (item=worker-4) => {"ansible_loop_var": "item", "attempts": 3, "changed": false, "item": "worker-4", "msg": "Failed GET request to 'https://mgmt-e16-h18-b01-fc640.rdu2.scalelab.redhat.com/redfish/v1/Chassis': 'Expecting value: line 1 column 1 (char 0)'"}
ok: [e16-h12-b01-fc640.rdu2.scalelab.redhat.com] => (item=worker-5)
...ignoring``
Fixes # (issue)

## Type of change

Please select the appropiate options:

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
