### PR TITLE
Adding the ability to turn off firmware and chassis inspection

### DIFF
--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -88,6 +88,10 @@ prov_ip=172.22.0.3
 # (Optional) Increase install process timeout by N iterations.
 #increase_install_timeout=2
 
+# (Optional) Disable RedFish inspection to intelligently choose between IPMI or RedFish protocol.
+# By default this feature is enabled and set to true. Uncomment below to disable and use IPMI.
+#redfish_inspection=false
+
 ######################################
 # Vars regarding install-config.yaml #
 ######################################

--- a/ansible-ipi-install/roles/node-prep/defaults/main.yml
+++ b/ansible-ipi-install/roles/node-prep/defaults/main.yml
@@ -14,3 +14,4 @@ provisioning_bridge: "provisioning"
 webserver_url: ""
 baremetal_bridge: "baremetal"
 disable_bmc_certificate_verification: false
+redfish_inspection: true

--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -357,6 +357,7 @@
   - "{{ groups.masters }}"
   - "{{ groups.workers | default([]) }}"
   ignore_errors: yes
+  when: redfish_inspection|bool
   tags: validation
 
 - name: Get all the firmware results from all the hosts
@@ -371,37 +372,48 @@
   - "{{ groups.masters }}"
   - "{{ groups.workers | default([]) }}"
   ignore_errors: yes
+  when: redfish_inspection|bool
   tags: validation
 
-- name: Add all the hosts that are Dell to a group with iDRAC firmware higher than 4.20.20.20
-  add_host:
-    groups: dell_hosts_redfish
-    hostname: "{{ chassis_result.results[item|int].item }}"
-  with_sequence: start=0 end="{{ numworkers|int + nummasters|int - 1 }}"
-  when:
-    - not chassis_result.results[{{ item }}].failed|bool
-    - not firmware_result.results[{{ item }}].failed|bool
-    - "'Dell' in chassis_result.results[{{ item }}].redfish_facts.chassis.entries[0].Manufacturer"
-    - firmware_result.results[{{ item }}].redfish_facts.firmware.entries | json_query(query) | max >= "4.20.20.20"
-  vars:
-    query: "[?Name=='Integrated Dell Remote Access Controller'].Version"
-  register: dell_host_redfish_result
-  retries: 6 # 1 minute (10 * 6)
-  delay: 10 # Every 10 seconds
-  ignore_errors: yes
+- name: Adding hosts to to their dynamic Dell inventory group
+  block:
+  - name: Add all the hosts that are Dell to a group with iDRAC firmware higher than 4.20.20.20
+    add_host:
+      groups: dell_hosts_redfish
+      hostname: "{{ chassis_result.results[item|int].item }}"
+    with_sequence: start=0 end="{{ numworkers|int + nummasters|int - 1 }}"
+    when:
+      - not chassis_result.results[{{ item }}].failed|bool
+      - not firmware_result.results[{{ item }}].failed|bool
+      - "'Dell' in chassis_result.results[{{ item }}].redfish_facts.chassis.entries[0].Manufacturer"
+      - firmware_result.results[{{ item }}].redfish_facts.firmware.entries | json_query(query) | max >= "4.20.20.20"
+    vars:
+      query: "[?Name=='Integrated Dell Remote Access Controller'].Version"
+    register: dell_host_redfish_result
+    retries: 6 # 1 minute (10 * 6)
+    delay: 10 # Every 10 seconds
+  rescue:
+  - name: Attempt to add all hosts that are part of the Dell group failed
+    debug:
+      msg: 'Adding hosts to dynamic Dell group failed or redfish_inspection was set to false. All inventory systems will use IPMI.'
   tags: validation
 
-- name: Add all the hosts that are HP to a group
-  add_host:
-    groups: hp_hosts_redfish
-    hostname: "{{ chassis_result.results[item|int].item }}"
-  with_sequence: start=0 end="{{ numworkers|int + nummasters|int - 1 }}"
-  when:
-    - not chassis_result.results[{{ item }}].failed|bool
-    - not firmware_result.results[{{ item }}].failed|bool
-    - "'HPE' in chassis_result.results[{{ item }}].redfish_facts.chassis.entries[0].Manufacturer"
-  register: hp_host_redfish_result
-  retries: 6 # 1 minute (10 * 6)
-  delay: 10 # Every 10 seconds
-  ignore_errors: yes
+- name: Adding hosts to to their dynamic HP inventory group
+  block:
+  - name: Add all the hosts that are HP to a group
+    add_host:
+      groups: hp_hosts_redfish
+      hostname: "{{ chassis_result.results[item|int].item }}"
+    with_sequence: start=0 end="{{ numworkers|int + nummasters|int - 1 }}"
+    when:
+      - not chassis_result.results[{{ item }}].failed|bool
+      - not firmware_result.results[{{ item }}].failed|bool
+      - "'HPE' in chassis_result.results[{{ item }}].redfish_facts.chassis.entries[0].Manufacturer"
+    register: hp_host_redfish_result
+    retries: 6 # 1 minute (10 * 6)
+    delay: 10 # Every 10 seconds
+  rescue: 
+  - name: Attempt to add all hosts that are part of the HP group failed
+    debug:
+      msg: 'Adding hosts to dynamic HP group failed or redfish_inspection was set to false. All inventory systems will use IPMI.'
   tags: validation

--- a/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
+++ b/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
@@ -97,6 +97,10 @@ prov_ip=172.22.0.3
 # (Optional) Increase install process timeout by N iterations.
 #increase_install_timeout=2
 
+# (Optional) Disable RedFish inspection to intelligently choose between IPMI or RedFish protocol.
+# By default this feature is enabled and set to true. Uncomment below to disable and use IPMI.
+#redfish_inspection=false
+
 ######################################
 # Vars regarding install-config.yaml #
 ######################################


### PR DESCRIPTION
# Description

Users would like the ability to disable hardware inspection in order to increase deployment time when they know they will use IPMI. This feature allows them to disable the inspection of the hardware to do just that. 

Fixes #507 

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
