### PR TITLE
Fixing pull secret location so it matches dir variable

### DIFF
--- a/ansible-ipi-install/roles/installer/vars/main.yml
+++ b/ansible-ipi-install/roles/installer/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 # vars file for installer
-pullsecret_file: "{{ ansible_user_dir }}/clusterconfigs/pull-secret.txt"
+pullsecret_file: "{{ dir }}/pull-secret.txt"
 cmd: openshift-baremetal-install
 default_libvirt_pool_dir: /var/lib/libvirt/images/
 


### PR DESCRIPTION
# Description

In the Ansible tool, if I change the dir variable to be something other than {{ ansible_user_dir }}/clusterconfigs, then the first task of https://github.com/openshift-kni/baremetal-deploy/blob/master/ansible-ipi-install/roles/installer/tasks/20_extract_installer.yml fails due to the dest target's path ({{ pullsecret_file }}) not existing. 

Fixes #508 

## Type of change

Please select the appropiate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
