### PR TITLE
Adding bootMode option to install config

### DIFF
--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -141,6 +141,9 @@ pullsecret=""
 #provisioningHostIP=<baremetal_net_IP1>
 #bootstrapProvisioningIP=<baremetal_net_IP2>
 
+# (Optional) Change the boot mode of the OpenShift cluster nodes to legacy mode (BIOS). Default is UEFI. 
+#bootmode=legacy
+
 # Master nodes
 # The hardware_profile is used by the baremetal operator to match the hardware discovered on the host
 # See https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md#baremetalhost-status

--- a/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
@@ -74,6 +74,9 @@ platform:
 {% endif %}
 {% endif %}
 {% if ((release_version[0]|int == 4) and (release_version[2]|int >= 6)) %}
+{% if bootmode is defined and bootmode == 'legacy' %}
+        bootMode: legacy
+{% endif %}
 {% if 'root_device_hint' in hostvars[host] and 'root_device_hint_value' in hostvars[host] and hostvars[host]['root_device_hint'] in roothint_list %}
         rootDeviceHints:
           {{ hostvars[host]['root_device_hint'] }}: {{ hostvars[host]['root_device_hint_value'] }}
@@ -105,6 +108,9 @@ platform:
 {% endif %}
 {% endif %}
 {% if ((release_version[0]|int == 4) and (release_version[2]|int >= 6)) %}
+{% if bootmode is defined and bootmode == 'legacy' %}
+        bootMode: legacy
+{% endif %}
 {% if 'root_device_hint' in hostvars[host] and 'root_device_hint_value' in hostvars[host] %}
         rootDeviceHints:
           {{ hostvars[host]['root_device_hint'] }}: {{ hostvars[host]['root_device_hint_value'] }}

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -72,6 +72,9 @@ platform:
 {% endif %}
 {% endif %}
 {% if ((release_version[0]|int == 4) and (release_version[2]|int >= 6)) %}
+{% if bootmode is defined and bootmode == 'legacy' %}
+        bootMode: legacy
+{% endif %}
 {% if 'root_device_hint' in hostvars[host] and 'root_device_hint_value' in hostvars[host] and hostvars[host]['root_device_hint'] in roothint_list %}
         rootDeviceHints:
           {{ hostvars[host]['root_device_hint'] }}: {{ hostvars[host]['root_device_hint_value'] }}
@@ -103,6 +106,9 @@ platform:
 {% endif %}
 {% endif %}
 {% if ((release_version[0]|int == 4) and (release_version[2]|int >= 6)) %}
+{% if bootmode is defined and bootmode == 'legacy' %}
+        bootMode: legacy
+{% endif %}
 {% if 'root_device_hint' in hostvars[host] and 'root_device_hint_value' in hostvars[host] %}
         rootDeviceHints:
           {{ hostvars[host]['root_device_hint'] }}: {{ hostvars[host]['root_device_hint_value'] }}


### PR DESCRIPTION
# Description

This pull request is to let user configure an option introduced in 4.6 installer in install-config.yaml to choose boot mode per host. 
New option available - https://github.com/openshift/installer/blob/release-4.6/docs/user/metal/install_ipi.md#install-config

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
