### PR TITLE
fix(10_get_oc.yml): use retries on uri module instead of get_url

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/10_get_oc.yml
+++ b/ansible-ipi-install/roles/installer/tasks/10_get_oc.yml
@@ -81,12 +81,14 @@
   - getoc
 
 - name: Get the ocp client tar gunzip file
-  get_url:
+  uri:
     url: "{{ release_url }}/{{ version }}/openshift-client-linux-{{ release_version }}.tar.gz"
     dest: "{{ temp_directory_loc }}"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: '0755'
+  retries: 6 # 1 minute (10 * 6)
+  delay: 10 # Every 10 seconds
   delegate_to: "{{ registry_creation | ternary(groups['registry_host'][0], groups['provisioner'][0]) }}"
   tags: getoc
 


### PR DESCRIPTION
# Description

Add retries on URI module instead of get_url for OC download

Closes #534

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
