### PR TITLE
docs(ipi-install-additional-install-config-parameters.adoc): make ipv…

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/documentation/ipi-install/modules/ipi-install-additional-install-config-parameters.adoc
@@ -128,7 +128,7 @@ ifeval::[{release} < 4.6]
 
 a|`provisioningNetworkCIDR`
 |`172.22.0.0/24`
-|The CIDR for the network to use for provisioning. This option is required when using IPv6 addressing on the `provisioning` network.
+|The CIDR for the network to use for provisioning. This option is required when not using the default address range on the `provisioning` network.
 endif::[]
 endif::[]
 
@@ -212,7 +212,9 @@ The `hosts` parameter is a list of separate bare metal assets used to build the 
 |
 | The MAC address of the NIC the host will use to boot on the `provisioning`  network.
 
+ifeval::[{release} < 4.6]
 | [[hardwareProfile]]`hardwareProfile`
 | `default`
 | This parameter exposes the device name that the installer attempts to deploy the {product-title} cluster for the control plane and worker nodes. The value defaults to `default` for control plane nodes and `unknown` for worker nodes. The list of profiles includes: `default`, `libvirt`, `dell`, `dell-raid`, and `openstack`. The `default` parameter attempts to install on `/dev/sda` of the {product-title} cluster nodes.
+endif::[]
 |===


### PR DESCRIPTION
ipv6 references reduction for more version compatibility and hide deprecated config from description

It covers:
-  https://github.com/openshift/openshift-docs/pull/26670
-  https://github.com/openshift/openshift-docs/pull/26671
