### PR TITLE
Add support for optional path for 55_customize_filesystem

### DIFF
--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -92,6 +92,13 @@ prov_ip=172.22.0.3
 # By default this feature is enabled and set to true. Uncomment below to disable and use IPMI.
 #redfish_inspection=false
 
+# (Optional) Modify files on the node filesystems, you can augment the "fake" roots for the 
+# control plane and worker nodes.
+# If defined, playbook will look for files in control plane and worker subdirectories.
+# Otherwise, it will look in {{ role_path }}/files/customize_filesystem (default)
+# For more information on modifying node filesystems visit: https://bit.ly/36tD30f
+#customize_node_filesystems="/path/to/customized/filesystems"
+
 ######################################
 # Vars regarding install-config.yaml #
 ######################################

--- a/ansible-ipi-install/roles/installer/tasks/55_customize_filesystem.yml
+++ b/ansible-ipi-install/roles/installer/tasks/55_customize_filesystem.yml
@@ -1,7 +1,11 @@
 ---
-- name: Verify if {{ role_path }}/files/customize_filesystem/master/worker is empty
+- name: Check if override path is defined for customize_filesystem
+  set_fact:
+    custom_path: "{{ customize_node_filesystems | default( role_path + '/files/customize_filesystem' ) }}"
+
+- name: Verify if {{ custom_path }}/master/worker is empty
   find:
-    paths: "{{ role_path }}/files/customize_filesystem/{{ item }}"
+    paths: "{{ custom_path }}/{{ item }}"
     recurse: yes
     follow: yes
   register: filesFound
@@ -29,7 +33,7 @@
 
   - name: Copy customize_filesystem to tempdir
     copy:
-      src: "{{ role_path }}/files/customize_filesystem"
+      src: "{{ custom_path }}"
       dest: "{{ tempdir }}"
       force: yes
 

--- a/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
+++ b/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
@@ -101,6 +101,13 @@ prov_ip=172.22.0.3
 # By default this feature is enabled and set to true. Uncomment below to disable and use IPMI.
 #redfish_inspection=false
 
+# (Optional) Modify files on the node filesystems, you can augment the "fake" roots for the 
+# control plane and worker nodes.
+# If defined, playbook will look for files in control plane and worker subdirectories.
+# Otherwise, it will look in {{ role_path }}/files/customize_filesystem (default)
+# For more information on modifying node filesystems visit: https://bit.ly/36tD30f
+#customize_node_filesystems="/path/to/customized/filesystems"
+
 ######################################
 # Vars regarding install-config.yaml #
 ######################################


### PR DESCRIPTION
This will allow users to specify an alternate file path for the fake
root filesystem outside of the role_path location.  It is backwards
compatible.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)
#570 

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Verify it pulls correct files when customize_ironic_path is defined
- [X] Verify it pulls role files when custom_ironic_path is not defined
- [X] Verify it pulls no files when customize_ironic_path is defined but no files
- [X] Verify it pulls no files when customize_ironic_path is undefined and no files at {{ role_path }}

**Test Configuration**:

- Versions: openshift 4.6
- Hardware: Virtualized, 3 masters 2 workers

## Checklist

- [X] I have performed a self-review of my own code
- [X] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [X] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
