### PR TITLE
Updating the upstream doc to reflect "installer-provisioned"

### DIFF
--- a/documentation/ipi-install/ipi-install-prerequisites.adoc
+++ b/documentation/ipi-install/ipi-install-prerequisites.adoc
@@ -1,14 +1,15 @@
 [id="ipi-install-prerequisites"]
 = Prerequisites
+include::modules/common-attributes.adoc[]
 :context: ipi-install-prerequisites
+:release: 4.6
 
 toc::[]
 
-Installing {product-title} with Installer Provisioned Infrastructure (IPI) requires:
+Installer-provisioned installation of {product-title} requires:
 
 . One provisioner node with RHEL 8.1 installed.
 . Three Control Plane nodes.
-. At least two worker nodes.
 . Baseboard Management Controller (BMC) access to each node.
 ifeval::[{release} > 4.5]
 . At least one network:
@@ -17,28 +18,24 @@ ifeval::[{release} > 4.5]
 .. One *optional* management network.
 endif::[]
 ifeval::[{release} < 4.6]
-. At least those networks:
+. At least two networks:
 .. One *required* routable network
 .. One *required* network for provisioning nodes; and,
 .. One *optional* management network.
 endif::[]
 
-Before installing {product-title} with IPI, ensure the hardware environment meets the following requirements.
 
-
+Before starting an installer-provisioned installation of {product-title}, ensure the hardware environment meets the following requirements.
 
 include::modules/ipi-install-node-requirements.adoc[leveloffset=+1]
 include::modules/ipi-install-network-requirements.adoc[leveloffset=+1]
-
 ifdef::upstream[]
 ifeval::[{release} >= 4.5]
 // Include IPv6 information only in DRAFT documentation
 include::modules/ipi-install-ipv6-network-requirements.adoc[leveloffset=+1]
 endif::[]
 endif::[]
-
 include::modules/ipi-install-configuring-nodes.adoc[leveloffset=+1]
-include::modules/ipi-install-configuring-networks.adoc[leveloffset=+1]
 include::modules/ipi-install-out-of-band-management.adoc[leveloffset=+1]
 include::modules/ipi-install-required-data-for-installation.adoc[leveloffset=+1]
 include::modules/ipi-install-validation-checklist-for-nodes.adoc[leveloffset=+1]

--- a/documentation/ipi-install/modules/ipi-install-config-yaml.adoc
+++ b/documentation/ipi-install/modules/ipi-install-config-yaml.adoc
@@ -7,7 +7,7 @@ networking:
   networkType: OVNKubernetes
 compute:
 - xref:workername[name]: worker
-  xref:computereplicas[replicas]: 2
+  xref:computereplicas[replicas]: 2 <1>
 controlPlane:
   xref:controlplanename[name]: master
   xref:controlplanereplicas[replicas]: 3
@@ -23,7 +23,7 @@ platform:
       - xref:name[name]: openshift-master-0
         xref:role[role]: master
         xref:bmcaddressing[bmc]:
-          address: ipmi://+<out-of-band-ip>+ # <1>
+          address: ipmi://+<out-of-band-ip>+ # <2>
           username: +<user>+
           password: +<password>+
         xref:bootMACAddress[bootMACAddress]: +<NIC1-mac-address>+

--- a/documentation/ipi-install/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/documentation/ipi-install/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -30,7 +30,8 @@ endif::[]
 
 ifdef::upstream[]
 +
-<1> Refer to the xref:bmcaddressing[BMC adressing] for more options
+<1> Scale the worker machines based on the number of worker nodes that are part of the {product-title} cluster.
+<2> Refer to the xref:bmcaddressing[BMC adressing] for more options
 endif::[]
 
 . Create a directory to store cluster configs.

--- a/documentation/ipi-install/modules/ipi-install-installing-rhel-on-the-provisioner-node.adoc
+++ b/documentation/ipi-install/modules/ipi-install-installing-rhel-on-the-provisioner-node.adoc
@@ -7,4 +7,4 @@
 
 = Installing RHEL on the provisioner node
 
-With the networking configuration complete, the next step is to install {op-system-base} 8.X on the provisioner node. The installer uses the provisioner node as the orchestrator while installing the {product-title} cluster on the three control plane nodes and the at least two worker nodes. For the purposes of this document, installing RHEL on the provisioner node is out of scope. However, options include but are not limited to using a RHEL Satellite server, PXE, or installation media.
+With the networking configuration complete, the next step is to install {op-system-base} 8.X on the provisioner node. The installer uses the provisioner node as the orchestrator while installing the {product-title} cluster. For the purposes of this document, installing RHEL on the provisioner node is out of scope. However, options include but are not limited to using a RHEL Satellite server, PXE, or installation media.

--- a/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
+++ b/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
@@ -1,11 +1,11 @@
-
+// Module included in the following assemblies:
 //
 // * installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
 
 [id='network-requirements_{context}']
 = Network requirements
 
-IPI installation involves several network requirements by default. First, IPI installation involves a non-routable `provisioning` network for provisioning the OS on each bare metal node and a routable `baremetal` network. Since IPI installation deploys `ironic-dnsmasq`, the networks should have no other DHCP servers running on the same broadcast domain. Network administrators *must* reserve IP addresses for each node in the {product-title} cluster.
+Installer-provisioned installation of {product-title} involves several network requirements by default. First, installer-provisioned installation involves a non-routable `provisioning` network for provisioning the OS on each bare metal node and a routable `baremetal` network. Since installer-provisioned installation deploys `ironic-dnsmasq`, the networks should have no other DHCP servers running on the same broadcast domain. Network administrators must reserve IP addresses for each node in the {product-title} cluster.
 
 .Network Time Protocol (NTP)
 
@@ -48,6 +48,7 @@ For assistance in configuring the DNS server, check xref:ipi-install-upstream-ap
 
 endif::[]
 
+
 .Reserving IP Addresses for Nodes with the DHCP Server
 
 For the `baremetal` network, a network administrator must reserve a number of IP addresses, including:
@@ -67,7 +68,7 @@ endif::[]
 
 . One IP Address for the provisioner node.
 . One IP address for each Control Plane (Master) node.
-. One IP address for each worker node.
+. One IP address for each worker node, if applicable.
 
 
 The following table provides an exemplary embodiment of hostnames for each node in the {product-title} cluster.
@@ -96,10 +97,9 @@ For assistance in configuring the DHCP server, check xref:ipi-install-upstream-a
 - xref:creating-dhcp-reservations-using-dnsmasq-option2_{context}[Creating DHCP reservations with dnsmasq (Option 2)]
 endif::[]
 
-
 .Additional requirements with no provisioning network
 
-All IPI installations require a `baremetal` network. The `baremetal` network is a routable network used for external network access to the outside world. In addition to the IP address supplied to the {product-title} cluster node, installations without a `provisioning` network require the following:
+All installer-provisioned installations require a `baremetal` network. The `baremetal` network is a routable network used for external network access to the outside world. In addition to the IP address supplied to the {product-title} cluster node, installations without a `provisioning` network require the following:
 
 - Setting an available IP address from the `baremetal` network to the `bootstrapProvisioningIP` configuration setting within the `install-config.yaml` configuration file.
 

--- a/documentation/ipi-install/modules/ipi-install-node-requirements.adoc
+++ b/documentation/ipi-install/modules/ipi-install-node-requirements.adoc
@@ -6,32 +6,32 @@
 
 = Node requirements
 
-IPI installation involves a number of hardware node requirements:
+Installer-provisioned installation involves a number of hardware node requirements:
 
 - **CPU architecture:** All nodes must use `x86_64` CPU architecture.
 
-- **Similar nodes:** It is recommended for nodes to have an identical configuration per role. That is, being the same brand and model with the same CPU, RAM and storage configuration.
+- **Similar nodes:** Red Hat recommends nodes have an identical configuration per role. That is, Red Hat recommends nodes be the same brand and model with the same CPU, memory and storage configuration.
 
 ifeval::[{release} < 4.5]
-- **Intelligent Platform Management Interface (IPMI):** IPI installation requires IPMI enabled on each node.
+- **Intelligent Platform Management Interface (IPMI):** Installer-provisioned installation requires IPMI enabled on each node.
 endif::[]
 
 ifeval::[{release} > 4.4]
 - **Baseboard Management Controller:** The `provisioner` node must be able to access the baseboard management controller (BMC) of each {product-title} cluster node. You may use IPMI, RedFish, or a proprietary protocol.
 endif::[]
 
-- **Latest generation:** Nodes must be of the most recent generation. IPI installation relies on BMC protocols, which must be compatible across nodes. Additionally, {op-system-base} 8 ships with the most recent drivers for RAID controllers. Ensure that the nodes are recent enough to support {op-system-base} 8 for the `provisioner` node and {op-system} 8 for the control plane and worker nodes.
+- **Latest generation:** Nodes must be of the most recent generation. Installer-provisioned installation relies on BMC protocols, which must be compatible across nodes. Additionally, {op-system-base} 8 ships with the most recent drivers for RAID controllers. Ensure that the nodes are recent enough to support {op-system-base} 8 for the `provisioner` node and {op-system} 8 for the control plane and worker nodes.
 
 - **Registry node:** (Optional) If setting up a disconnected mirrored registry, it is recommended the registry reside in its own node.
 
-- **Provisioner node:** IPI installation requires one `provisioner` node.
+- **Provisioner node:** Installer-provisioned installation requires one `provisioner` node.
 
-- **Control plane:** IPI installation requires three control plane nodes for high availability.
+- **Control plane:** Installer-provisioned installation requires three control plane nodes for high availability.
 
-- **Worker nodes:** A typical production cluster will have many worker nodes. IPI installation in a high availability environment requires at least two worker nodes in an initial cluster.
+- **Worker nodes:** While not required, a typical production cluster has one or more worker nodes. Smaller clusters provide are more resource efficient for administrators and developers during development, production, and testing. 
 
 - **Network interfaces:** Each node must have at least one 10GB network interface for the routable `baremetal` network. Each node must have one 10GB network interface for a `provisioning` network *when using the `provisioning` network* for deployment. Using the `provisioning` network is the default configuration. Network interface names must follow the same naming convention across all nodes. For example, the first NIC name on a node, such as `eth0` or `eno1`, must be the same name on all of the other nodes. The same principle applies to the remaining NICs on each node.
 
 ifeval::[{release} > 4.3]
-- **Unified Extensible Firmware Interface (UEFI):** Installation requires UEFI boot on all {product-title} nodes when using IPv6 addressing on the `provisioning` network. In addition, UEFI Device PXE Settings must be set to use the IPv6 protocol on the `provisioning` network NIC, but *omitting the `provisioning` network removes this requirement.*
+- **Unified Extensible Firmware Interface (UEFI):** Installer-provisioned installation requires UEFI boot on all {product-title} nodes when using IPv6 addressing on the `provisioning` network. In addition, UEFI Device PXE Settings must be set to use the IPv6 protocol on the `provisioning` network NIC, but *omitting the `provisioning` network removes this requirement.*
 endif::[]


### PR DESCRIPTION
Updating the upstream doc to reflect "installer-provisioned" rather than IPI. Changed worker node description too. Removed the configuring networks topic as it was just a link to an unpublished KCS article. Updated callouts in install-config.yaml. Also restored conditional text that was removed in the downstream doc.

Signed-off-by: John Wilkins <jowilkin@redhat.com>

