### PR TITLE
Add missed pipe

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-creating-a-disconnected-registry.adoc
+++ b/documentation/ipi-install/modules/ipi-install-creating-a-disconnected-registry.adoc
@@ -157,7 +157,7 @@ Copy the pull secret file from the provisioner node to the registry node and mod
 +
 [source,terminal]
 ----
-[user@registry ~]$ b64auth=$( echo -n '<username>:<passwd>' openssl base64 )
+[user@registry ~]$ b64auth=$( echo -n '<username>:<passwd>' | openssl base64 )
 ----
 +
 Replace `<username>` with the user name and `<passwd>` with the password.


### PR DESCRIPTION

Due to miss a pipe, the string can't covert to base64-formated string

From 
```bash
echo -n '<username>:<passwd>' openssl base64
```

To
```bash
echo -n '<username>:<passwd>' | openssl base64
```

Signed-off-by: Phil Huang <phil.huang@redhat.com>
