### PR TITLE
Added firmware requirements for virtual media.

### DIFF
--- a/documentation/ipi-install/ipi-install-prerequisites.adoc
+++ b/documentation/ipi-install/ipi-install-prerequisites.adoc
@@ -28,6 +28,9 @@ endif::[]
 Before starting an installer-provisioned installation of {product-title}, ensure the hardware environment meets the following requirements.
 
 include::modules/ipi-install-node-requirements.adoc[leveloffset=+1]
+ifeval::[{release} >= 4.6]
+include::modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc[leveloffset=+1]
+endif::[]
 include::modules/ipi-install-network-requirements.adoc[leveloffset=+1]
 ifdef::upstream[]
 ifeval::[{release} >= 4.5]

--- a/documentation/ipi-install/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/documentation/ipi-install/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -1,0 +1,30 @@
+
+[id='ipi-install-firmware-requirements-for-installing-with-virtual-media_{context}']
+
+= Firmware requirements for installing with virtual media
+
+The installer for installer-provisioned {product-title} clusters validates the hardware and firmware compatibility with RedFish virtual media. The following table lists supported firmware for installer-provisioned {product-title} clusters deployed with RedFish virtual media.
+
+.Firmware Compatibility for RedFish Virtual Media
+[frame="topbot", options="header"]
+|====
+|Hardware| Model | Management | Minimum Firmware Version
+.2+| HP | 10th Generation | iLO5 | v1.9
+| 9th Generation | iLO4 | v1.8
+
+.2+| Dell | 14th Generation | iDRAC 9 | v4.20.20.20+
+
+| 13th Generation .2+| iDRAC 8 | v2.75.75.75+
+
+|====
+
+[NOTE]
+====
+Refer to your hardware documentation or contact your vendor for information on updating your firmware.
+====
+
+
+[IMPORTANT]
+====
+The installer will not initiate installation on a node if the node firmware is below the foregoing versions when installing with virtual media.
+====

--- a/documentation/ipi-install/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/documentation/ipi-install/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -9,8 +9,8 @@ The installer for installer-provisioned {product-title} clusters validates the h
 [frame="topbot", options="header"]
 |====
 |Hardware| Model | Management | Minimum Firmware Version
-.2+| HP | 10th Generation | iLO5 | v1.9
-| 9th Generation | iLO4 | v1.8
+.2+| HP | 10th Generation | iLO5 | N/A
+| 9th Generation | iLO4 | N/A
 
 .2+| Dell | 14th Generation | iDRAC 9 | v4.20.20.20+
 
@@ -20,7 +20,7 @@ The installer for installer-provisioned {product-title} clusters validates the h
 
 [NOTE]
 ====
-Refer to your hardware documentation or contact your vendor for information on updating your firmware.
+Refer to the hardware documentation for the nodes or contact the hardware vendor for information on updating the firmware.
 
 For Dell servers, ensure the {product-title} cluster nodes have AutoAttach Enabled through the iDRAC console. The menu path is: **Configuration->Virtual Media->Attach Mode->AutoAttach**.
 ====

--- a/documentation/ipi-install/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/documentation/ipi-install/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -21,8 +21,9 @@ The installer for installer-provisioned {product-title} clusters validates the h
 [NOTE]
 ====
 Refer to your hardware documentation or contact your vendor for information on updating your firmware.
-====
 
+For Dell servers, ensure the {product-title} cluster nodes have AutoAttach Enabled through the iDRAC console. The menu path is: **Configuration->Virtual Media->Attach Mode->AutoAttach**.
+====
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Signed-off-by: John Wilkins <jowilkin@redhat.com>

# Description

This module describes the firmware requirements for deploying OCP using installer-provisioned infrastructure and virtual media.

Fixes # KNI-deploy-2088 and telcodocs-108

@rlopez133
@iranzo

## Type of change

Please select the appropiate options:

- [x ] This change is a documentation update

Need to invite imelofer@redhat.com and omichaeli to the repo. 
