### PR TITLE
Added references to the Day 0 firmware requirements for virtual media.

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-bmc-addressing.adoc
+++ b/documentation/ipi-install/modules/ipi-install-bmc-addressing.adoc
@@ -118,6 +118,24 @@ platform:
           password: <password>
 ----
 
+While it is recommended to have a certificate of authority for the
+out-of-band management addresses, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. The following example demonstrates a RedFish configuration using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish-virtualmedia://<out-of-band-ip>/redfish/v1/Systems/1
+          username: <user>
+          password: <password>
+          disableCertificateVerification: True
+----
+
+
 [NOTE]
 ====
 Deploying with RedFish Virtual Media involves meeting minimum firmware requirements. See *Firmware requirements for installing with virtual media* in the *Prerequisites* section for details.
@@ -151,6 +169,24 @@ platform:
           username: <user>
           password: <password>
 ----
+
+While it is recommended to have a certificate of authority for the
+out-of-band management addresses, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. The following example demonstrates a RedFish configuration using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: idrac-virtualmedia://<out-of-band-ip>/redfish/v1/Systems/System.Embedded.1
+          username: <user>
+          password: <password>
+          disableCertificateVerification: True
+----
+
 
 [NOTE]
 ====

--- a/documentation/ipi-install/modules/ipi-install-bmc-addressing.adoc
+++ b/documentation/ipi-install/modules/ipi-install-bmc-addressing.adoc
@@ -118,6 +118,11 @@ platform:
           password: <password>
 ----
 
+[NOTE]
+====
+Deploying with RedFish Virtual Media involves meeting minimum firmware requirements. See *Firmware requirements for installing with virtual media* in the *Prerequisites* section for details.
+====
+
 
 .RedFish Virtual Media for Dell
 
@@ -147,10 +152,7 @@ platform:
           password: <password>
 ----
 
-
 [NOTE]
 ====
-`idrac-virtualmedia` requires iDRAC firmware version 4.20.20.20 or higher.
-
-Ensure the {product-title} cluster nodes have AutoAttach Enabled through the iDRAC console. The menu path is: **Configuration->Virtual Media->Attach Mode->AutoAttach**.
+Deploying with RedFish Virtual Media involves meeting minimum firmware requirements. See *Firmware requirements for installing with virtual media* in the *Prerequisites* section for details.
 ====


### PR DESCRIPTION
Signed-off-by: John Wilkins <jowilkin@redhat.com>

@rlopez133 
@iranzo 

# Description

In lieu of a Day 1 operation, the BMC addressing section contains a note referring virtual media users to the firmware requirements section. 

Fixes # Telcodocs 109

## Type of change

- [x] This change is a documentation update

