### PR TITLE
Added a comment for Day 2, expanding the cluster

### DIFF
--- a/documentation/ipi-install/ipi-install-expanding-the-cluster.adoc
+++ b/documentation/ipi-install/ipi-install-expanding-the-cluster.adoc
@@ -6,6 +6,11 @@
 
 After deploying an installer-provisioned {product-title} cluster, you can use the following procedures to expand the number of worker nodes. Ensure that each prospective worker node meets the prerequisites.
 
+[NOTE]
+====
+Expanding the cluster using RedFish Virtual Media involves meeting minimum firmware requirements. See *Firmware requirements for installing with virtual media* in the *Prerequisites* section for additional details when expanding the cluster using RedFish Virtual Media.
+====
+
 include::modules/ipi-install-preparing-the-bare-metal-node.adoc[leveloffset=+1]
 
 include::modules/ipi-install-provisioning-the-bare-metal-node.adoc[leveloffset=+1]

--- a/documentation/ipi-install/ipi-install-troubleshooting.adoc
+++ b/documentation/ipi-install/ipi-install-troubleshooting.adoc
@@ -20,7 +20,7 @@ _Workflow 2 of 4_ illustrates a troubleshooting workflow for xref:ipi-install-tr
 
 image:flow3.png[Flow-Diagram-3]
 
-_Workflow 3 of 4_ illustrates a troubleshooting workflow for xref:ipi-install-troubleshooting-cluster-nodes-will-not-pxe_{context}[ cluster nodes that will not PXE boot].
+_Workflow 3 of 4_ illustrates a troubleshooting workflow for xref:ipi-install-troubleshooting-cluster-nodes-will-not-pxe_{context}[ cluster nodes that will not PXE boot]. If installing using RedFish Virtual Media, each node must meet  minimum firmware requirements for the installer to deploy the node. See *Firmware requirements for installing with virtual media* in the *Prerequisites* section for additional details.
 
 image:flow4.png[Flow-Diagram-4]
 


### PR DESCRIPTION
Added a comment for Day 2, expanding the cluster, noting the need to meet minimum firmware requirements when expanding the cluster.

@rlopez133 
@iranzo 

Signed-off-by: John Wilkins <jowilkin@redhat.com>

# Description

Per Telcodocs 131, we should provide information on firmware requirements when expanding the cluster with virtual media. The note redirects the user to the prerequisites and the module on firmware requirements when deploying with virtual media. 

Fixes # telcodocs-13`

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change is a documentation update
