### PR TITLE
Add optional path customized extra manifests

### DIFF
--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -99,6 +99,11 @@ prov_ip=172.22.0.3
 # For more information on modifying node filesystems visit: https://bit.ly/36tD30f
 #customize_node_filesystems="/path/to/customized/filesystems"
 
+# (Optional) Modify the path to add external manifests to the deployed nodes.
+# If defined, the playbook will copy manifests from the user provided directory.
+# Otherwise, files will be copied from the default location 'roles/installer/files/manifests/*'
+#customize_extramanifests_path="/path/to/extra/manifests
+
 ######################################
 # Vars regarding install-config.yaml #
 ######################################

--- a/ansible-ipi-install/roles/installer/tasks/50_extramanifests.yml
+++ b/ansible-ipi-install/roles/installer/tasks/50_extramanifests.yml
@@ -1,4 +1,8 @@
 ---
+- name: Check if override path is defined for extramanifests
+  set_fact:
+    extramanifests_path: "{{ customize_extramanifests_path | default( 'roles/installer/files/manifests/*' ) }}"
+
 - name: Add Manifests from files dir
   copy:
     src: "{{ item }}"
@@ -6,7 +10,7 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
   with_fileglob:
-    - roles/installer/files/manifests/*
+    - "{{ extramanifests_path }}"
   tags: extramanifests
 
 - name: Manage chrony configuration

--- a/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
+++ b/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
@@ -108,6 +108,11 @@ prov_ip=172.22.0.3
 # For more information on modifying node filesystems visit: https://bit.ly/36tD30f
 #customize_node_filesystems="/path/to/customized/filesystems"
 
+# (Optional) Modify the path to add external manifests to the deployed nodes.
+# If defined, the playbook will copy manifests from the user provided directory.
+# Otherwise, files will be copied from the default location 'roles/installer/files/manifests/*'
+#customize_extramanifests_path="/path/to/extra/manifests
+
 ######################################
 # Vars regarding install-config.yaml #
 ######################################


### PR DESCRIPTION
This patch adds an optional parameter allowing a custom path to
be defined for the location of files copied by 50_extramanifests.yml

# Description

As per a conversation with Roger, this patch adds an optional extramanifests_path to the inventory. This parameter is used to customize the source path used by 50_extramanifests.yml. By default files are copied from a path withing the ansible-ipi-install subdirectory.
Fixes # (issue)

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
Ran deployment with out the parameter defined. The default path was used. Verified by adding an additional debug: statement before using the next play.
- [x] Test B
Ran deployment with the parameter defined. The defined path was used. Verified by adding an additional debug: statement before using the next play.

**Test Configuration**:

- Versions:
current version of ansible-ipi-install playbooks from github
- Hardware:
6 node virtual cluster

## Checklist

- [x] I have performed a self-review of my own code
- [x] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
