### PR TITLE
Added Day 1 steps for enabling SecureBoot.

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-configuring-nodes.adoc
+++ b/documentation/ipi-install/modules/ipi-install-configuring-nodes.adoc
@@ -59,3 +59,20 @@ The installation process requires one NIC:
 NICx is a routable network (`baremetal`) that is used for the installation of the {product-title} cluster, and routable to the internet.
 
 endif::[]
+
+ifeval::[{release} > 4.6]
+.Configuring nodes for SecureBoot
+
+SecureBoot prevents a node from booting unless it verifies the node is using only trusted software, such as UEFI firmware drivers, EFI applications and the operating system. Red Hat only supports SecureBoot when deploying with RedFish Virtual Media.
+
+To enable SecureBoot, refer to the hardware guide for the node. You must perform the following:
+
+. Enable booting with UEFI. SecureBoot requires UEFI enabled.
+. Enable SecureBoot. Nodes usually disable SecureBoot by default.
+. Configure the key.
++
+[IMPORTANT]
+====
+Red Hat does not support SecureBoot with self-generated keys.
+====
+endif::[]

--- a/documentation/ipi-install/modules/ipi-install-configuring-nodes.adoc
+++ b/documentation/ipi-install/modules/ipi-install-configuring-nodes.adoc
@@ -65,11 +65,11 @@ ifeval::[{release} > 4.6]
 
 SecureBoot prevents a node from booting unless it verifies the node is using only trusted software, such as UEFI firmware drivers, EFI applications and the operating system. Red Hat only supports SecureBoot when deploying with RedFish Virtual Media.
 
-To enable SecureBoot, refer to the hardware guide for the node. You must perform the following:
+To enable SecureBoot, refer to the hardware guide for the node. To enable SecureBoot, execute the following:
 
-. Enable booting with UEFI. SecureBoot requires UEFI enabled.
-. Enable SecureBoot. Nodes usually disable SecureBoot by default.
-. Configure the key.
+. Boot the node and enter the BIOS menu.
+. Set the node's boot mode to UEFI Enabled.
+. Enable SecureBoot.
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
Signed-off-by: John Wilkins <jowilkin@redhat.com>

# Description

See https://issues.redhat.com/browse/TELCODOCS-127 and https://issues.redhat.com/browse/KNIDEPLOY-3883 for details. In 4.7, Red Hat supports SecureBoot when deploying with RedFish Virtual media. Nodes must have UEFI enabled, Secure Boot enabled, and use a trusted key. Self-generated keys aren't supported.

Fixes # telcodocs-127

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change is a documentation update
