### PR TITLE
Initial cut of iRMC for Fujitsu. 

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-bmc-addressing.adoc
+++ b/documentation/ipi-install/modules/ipi-install-bmc-addressing.adoc
@@ -154,3 +154,20 @@ platform:
 
 Ensure the {product-title} cluster nodes have AutoAttach Enabled through the iDRAC console. The menu path is: **Configuration->Virtual Media->Attach Mode->AutoAttach**.
 ====
+
+.iRMC for Fujitsu
+
+Fujitsu nodes can use `irmc://<out-of-band-ip>` and defaults to port `623`. The following example demonstrates an iRMC configuration within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: irmc://<out-of-band-ip>
+          username: <user>
+          password: <password>
+----

--- a/documentation/ipi-install/modules/ipi-install-bmc-addressing.adoc
+++ b/documentation/ipi-install/modules/ipi-install-bmc-addressing.adoc
@@ -155,6 +155,7 @@ platform:
 Ensure the {product-title} cluster nodes have AutoAttach Enabled through the iDRAC console. The menu path is: **Configuration->Virtual Media->Attach Mode->AutoAttach**.
 ====
 
+ifeval::[{release}> 4.6]
 .iRMC for Fujitsu
 
 Fujitsu nodes can use `irmc://<out-of-band-ip>` and defaults to port `623`. The following example demonstrates an iRMC configuration within the `install-config.yaml` file.
@@ -171,3 +172,4 @@ platform:
           username: <user>
           password: <password>
 ----
+endif::[]


### PR DESCRIPTION
@rlopez133 
@iranzo 

Signed-off-by: John Wilkins <jowilkin@redhat.com>

# Description

This is an initial cut based on https://issues.redhat.com/browse/TELCODOCS-111. I based this on the content received in telcodocs 111 and conversation with Dmitri. However, it seems to me that we should also include sections for RedFish and RedFish with Virtual Media for Fujitsu, since we only support SecureBoot with RedFish Virtual Media. According to their S5 spec, they do have RedFish and Virtual media. See https://www.reckzigel.at/wp-content/uploads/2018/03/irmc-s5-configuration-en.pdf for additional details.

Fixes # telcodocs-111

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change is a documentation update

