### PR TITLE
Added text regarding infinite leases to create static IP addresses.

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
+++ b/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
@@ -70,6 +70,13 @@ endif::[]
 . One IP address for each Control Plane (Master) node.
 . One IP address for each worker node, if applicable.
 
+ifeval::[{release}>4.6]
+[IMPORTANT]
+.Reserving IP addresses so they become static IP addresses
+====
+Some administrators prefer to use static IP addresses so that each node's IP address remains constant in the absence of a DHCP server. To use static IP addresses in the {product-title} cluster, **reserve the IP addresses with an infinite lease**. During deployment, the installer will reconfigure the NICs from DHCP assigned addresses to static IP addresses. NICs with DHCP leases that are not infinite will remain configured to use DHCP.
+====
+endif::[]
 
 The following table provides an exemplary embodiment of hostnames for each node in the {product-title} cluster.
 


### PR DESCRIPTION
Fixes: telcodocs-35
https://issues.redhat.com/browse/TELCODOCS-35

Signed-off-by: John Wilkins <jowilkin@redhat.com>

# Description

In OCP 4.7 and beyond, reserving an IP address in the DHCP server with an infinite lease will trigger the installer to reconfigure the NIC with a static IP address, thereby enabling operation without a DHCP server. This is done for reliability if a DHCP server fails, or if the administrator does not want to maintain a DHCP server in the environment.

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change is a documentation update
