### PR TITLE
Day 0 description of requirements.

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
+++ b/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
@@ -119,13 +119,16 @@ All installer-provisioned installations require a `baremetal` network. The `bare
 Configuring additional IP addresses for `bootstrapProvisioningIP` and `provisioningHostIP` is not required when using a `provisioning` network.
 ====
 
-.State-driven network configuration requirements
 
-{product-title} supports additional post-installation state-driven network configuration on the secondary network interfaces of cluster nodes using `nmstate`. For example, system administrators might configure a secondary network interface on cluster nodes after installation for a storage network.
+ifeval::[{release} > 4.6]
+.State-driven network configuration requirements (Technology Preview)
+
+{product-title} supports additional post-installation state-driven network configuration on the secondary network interfaces of cluster nodes using `kubernetes-nmstate`. For example, system administrators might configure a secondary network interface on cluster nodes after installation for a storage network.
 
 [NOTE]
 ====
 Configuration must occur before scheduling pods.
 ====
 
-State-driven network configuration requires installing `nmstate`, and also requires NetworkManager running on the cluster nodes.
+State-driven network configuration requires installing `kubernetes-nmstate`, and also requires NetworkManager running on the cluster nodes. See **Post-installation configuration** for additional details.
+endif::[]

--- a/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
+++ b/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
@@ -118,3 +118,14 @@ All installer-provisioned installations require a `baremetal` network. The `bare
 ====
 Configuring additional IP addresses for `bootstrapProvisioningIP` and `provisioningHostIP` is not required when using a `provisioning` network.
 ====
+
+.State-driven network configuration requirements
+
+{product-title} supports additional post-installation state-driven network configuration on the secondary network interfaces of cluster nodes using `nmstate`. For example, system administrators might configure a secondary network interface on cluster nodes after installation for a storage network.
+
+[NOTE]
+====
+Configuration must occur before scheduling pods.
+====
+
+State-driven network configuration requires installing `nmstate`, and also requires NetworkManager running on the cluster nodes.


### PR DESCRIPTION
Fixes: TELCODOCS-137
https://issues.redhat.com/browse/TELCODOCS-137
@rlopez133 
@iranzo

Signed-off-by: John Wilkins <jowilkin@redhat.com>

# Description

Adds requirements for state-driven network configuration requirements, which are having `nmstate` installed and the cluster nodes running NetworkManager. 

## Type of change

Please select the appropriate options:

- [x] This change is a documentation update

