### PR TITLE
Knideploy 3704 doc

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/documentation/ipi-install/modules/ipi-install-additional-install-config-parameters.adoc
@@ -144,16 +144,14 @@ a|`provisioningNetworkCIDR`
 |`bootstrapProvisioningIP`
 |The second IP address of the `provisioningNetworkCIDR`.
 |The IP on the bootstrap VM where the provisioning services run while the the installer is deploying the control plane (master) nodes. Defaults to the second IP of the `provisioning` subnet. For example, `172.22.0.2`
-ifdef::upstream[]
 ifeval::[{release} >= 4.5]
-or `2620:52:0:1307::2`.
+or `2620:52:0:1307::2`
 endif::[]
-ifeval::[{release} >= 4.6]
+.
+
+ifeval::[{release} == 4.6]
 Set this parameter to an available IP address on the `baremetal` network when the `provisioningNetwork` configuration setting is set to `Disabled`.
 endif::[]
-endif::[]
-
- When using no `provisioning` network, set this value to an IP address that is available on the `baremetal` network.
 
 | `externalBridge`
 | `baremetal`

--- a/documentation/ipi-install/modules/ipi-install-configuration-files.adoc
+++ b/documentation/ipi-install/modules/ipi-install-configuration-files.adoc
@@ -1,7 +1,7 @@
 [id="ipi-install-configuration-files"]
 = Configuration Files
 :context: ipi-install-configuration-files
-:release: 4.6
+//:release: 4.6
 
 In this section of the document, we will be covering the set-up of the different configuration files
 

--- a/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
+++ b/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
@@ -104,6 +104,7 @@ For assistance in configuring the DHCP server, check xref:ipi-install-upstream-a
 - xref:creating-dhcp-reservations-using-dnsmasq-option2_{context}[Creating DHCP reservations with dnsmasq (Option 2)]
 endif::[]
 
+ifeval::[{release} == 4.6]
 .Additional requirements with no provisioning network
 
 All installer-provisioned installations require a `baremetal` network. The `baremetal` network is a routable network used for external network access to the outside world. In addition to the IP address supplied to the {product-title} cluster node, installations without a `provisioning` network require the following:
@@ -118,3 +119,4 @@ All installer-provisioned installations require a `baremetal` network. The `bare
 ====
 Configuring additional IP addresses for `bootstrapProvisioningIP` and `provisioningHostIP` is not required when using a `provisioning` network.
 ====
+endif::[]


### PR DESCRIPTION
# Description

Per conversation with Roger, added conditional text to "Additional requirements with no provisioning network" to make it 4.6 only. 

Also made comment for disabled provisioning network with bootstrapProvisioningIP 4.6 only per conversation with @rlopez133.


Fixes # TELCODOCS-121

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change is a documentation update