### PR TITLE
Replaced ocp-dev-preview with ocp from downstream version. 

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-preparing-the-bare-metal-node.adoc
+++ b/documentation/ipi-install/modules/ipi-install-preparing-the-bare-metal-node.adoc
@@ -24,7 +24,7 @@ Preparing the bare metal node requires executing the following procedure from th
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/$VERSION/openshift-client-linux.tar.gz | tar zxvf - oc
+[kni@provisioner ~]$ curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$VERSION/openshift-client-linux-$VERSION.tar.gz | tar zxvf - oc
 ----
 +
 [source,bash]
@@ -32,31 +32,7 @@ Preparing the bare metal node requires executing the following procedure from th
 [kni@provisioner ~]$ sudo cp oc /usr/local/bin
 ----
 
-. Install the `ipmitool`.
-+
-[source,bash]
-----
-[kni@provisioner ~]$ sudo dnf install -y OpenIPMI ipmitool
-----
-
-. Power off the bare metal node and ensure it is off.
-+
-[source,bash]
-----
-[kni@provisioner ~]$ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power off
-----
-+
-Where `<management-server-ip>` is the IP address of the bare metal node's base board management controller.
-+
-[source,bash]
-----
-[kni@provisioner ~]$ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power status
-----
-+
-[source,bash]
-----
-Chassis Power is off
-----
+. Power off the bare metal node via the baseboard management controller and ensure it is off.
 
 . Retrieve the username and password of the bare metal node's baseboard management controller. Then, create `base64` strings from the username and password. In the following example, the username is `root` and the password is `calvin`.
 +
@@ -97,11 +73,14 @@ spec:
   online: true
   bootMACAddress: <NIC1-mac-address>
   bmc:
-    address: ipmi://<bmc-ip>
+    address: <protocol>://<bmc-ip>
     credentialsName: openshift-worker-<num>-bmc-secret
 ----
 +
-Replace `<num>` for the worker number of bare metal node in two `name` fields and `credentialsName` field. Replace `<base64-of-uid>` with the `base64` string of the username. Replace `<base64-of-pwd>` with the `base64` string of the password. Replace `<NIC1-mac-address>` with the MAC address of the bare metal node's first NIC. Replace `<bmc-ip>` with the IP address of the bare metal node's baseboard management controller.
+Replace `<num>` for the worker number of bare metal node in the two `name` fields and `credentialsName` field. Replace `<base64-of-uid>` with the `base64` string of the username. Replace `<base64-of-pwd>` with the `base64` string of the password. Replace `<NIC1-mac-address>` with the MAC address of the bare metal node's first NIC.
++
+Refer to the BMC addressing section for additional BMC configuration options. Replace `<protocol>` with the BMC protocol, such as IPMI, RedFish, or others.
+Replace `<bmc-ip>` with the IP address of the bare metal node's baseboard management controller.
 
 . Create the bare metal node.
 +


### PR DESCRIPTION
@iranzo 
@rlopez133 

Signed-off-by: John Wilkins <jowilkin@redhat.com>

# Description

Removed the concrete IPMI instructions and made them generic. Fixed the ocp-dev-preview URL from the version in the downsteram docs. Note: I still see other ocp-dev-preview instances in other upstream modules. These instances should probably be replaced too. Removed ipmi from the BMC section of the config file and made a generic <protocol> example, and referred users to the BMC addressing section. Modules still cannot contain hyperlinks in the downstream. 


Fixes # telcodocs-129

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change is a documentation update
