### PR TITLE
Day 0 description of requirements for using kubernetes-nmstate.

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
+++ b/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
@@ -120,3 +120,16 @@ All installer-provisioned installations require a `baremetal` network. The `bare
 Configuring additional IP addresses for `bootstrapProvisioningIP` and `provisioningHostIP` is not required when using a `provisioning` network.
 ====
 endif::[]
+
+ifeval::[{release} > 4.6]
+.State-driven network configuration requirements (Technology Preview)
+
+{product-title} supports additional post-installation state-driven network configuration on the secondary network interfaces of cluster nodes using `kubernetes-nmstate`. For example, system administrators might configure a secondary network interface on cluster nodes after installation for a storage network.
+
+[NOTE]
+====
+Configuration must occur before scheduling pods.
+====
+
+State-driven network configuration requires installing `kubernetes-nmstate`, and also requires NetworkManager running on the cluster nodes. See **OpenShift Virtualization > Kubernetes NMState (Tech Preview)** for additional details.
+endif::[]


### PR DESCRIPTION
Fixes: TELCODOCS-137
@iranzo 
@rlopez133 

Signed-off-by: John Wilkins <jowilkin@redhat.com>

# Description

Adds requirements for state-driven network configuration using kubernetes-nmstate operator, which are having nmstate installed and the cluster nodes running NetworkManager.

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change is a documentation update
