### PR TITLE
Added clarifying language per Bugzilla 1914440.

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
+++ b/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
@@ -78,7 +78,7 @@ Some administrators prefer to use static IP addresses so that each node's IP add
 ====
 endif::[]
 
-The following table provides an exemplary embodiment of hostnames for each node in the {product-title} cluster.
+The following table provides an exemplary embodiment of fully-qualified domain names. The API and Nameserver addresses begin with canonical name extensions. The hostnames of the control plane and worker nodes are exemplary, so you may use any host naming convention you prefer. 
 
 [width="100%", cols="3,5e,2e", frame="topbot",options="header"]
 |=====


### PR DESCRIPTION
Fixes: 1914440
https://bugzilla.redhat.com/show_bug.cgi?id=1914440
Signed-off-by: John Wilkins <jowilkin@redhat.com>

@rlopez133 

# Description

Customer suggested clarifying the network requirements table to note that hostnames are arbitrary and they can use whatever host naming convention they prefer. 

Fixes # BZ 1914440

## Type of change

Please select the appropiate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change is a documentation update