### PR TITLE
Allow IPv6 bmc ip addresses

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -348,7 +348,7 @@
   redfish_info:
     category: Chassis
     command: GetChassisInventory
-    baseuri: "{{ hostvars[item]['ipmi_address'] }}"
+    baseuri: "{{ hostvars[item]['ipmi_address']|ipwrap }}"
     username: "{{ hostvars[item]['ipmi_user'] }}"
     password: "{{ hostvars[item]['ipmi_password'] }}"
   register: chassis_result
@@ -366,7 +366,7 @@
   redfish_info:
     category: Update
     command: GetFirmwareInventory
-    baseuri: "{{ hostvars[item]['ipmi_address'] }}"
+    baseuri: "{{ hostvars[item]['ipmi_address']|ipwrap }}"
     username: "{{ hostvars[item]['ipmi_user'] }}"
     password: "{{ hostvars[item]['ipmi_password'] }}"
   register: firmware_result


### PR DESCRIPTION
Validation was failing to get host details when using IPv6 BMC addresses.
