### PR TITLE
Fix customize override logic

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/55_customize_filesystem.yml
+++ b/ansible-ipi-install/roles/installer/tasks/55_customize_filesystem.yml
@@ -33,8 +33,8 @@
 
   - name: Copy customize_filesystem to tempdir
     copy:
-      src: "{{ custom_path }}"
-      dest: "{{ tempdir }}"
+      src: "{{ custom_path }}/"
+      dest: "{{ tempdir }}/customize_filesystem"
       force: yes
 
   - name: Cleanup Any .gitkeep Files in the Fake Root


### PR DESCRIPTION
# Description

If the override path didn't end in customize_filesystem it would fail to
find the customized files.

Fixes #663 

## Type of change

Please select the appropiate options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

Tested in the Dallas lab with a custom path that doesn't end in If the override path didn't end in customize_filesystem

- [X] customize_node_filesystems=/etc/dci-openshift-agent/customize_filesystem
- [X] customize_node_filesystems="/opt/baremetal-deploy/ansible-ipi-install/roles/installer/files/customize_filesystem_cluster1"

**Test Configuration**:

- Versions: 70f628dd3a05be650506f7d558f6541bf15f65a8

## Checklist

- [X] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [X] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not being merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
