### PR TITLE
Added support for manifests folder customization

### DIFF
--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -92,7 +92,7 @@ prov_ip=172.22.0.3
 # By default this feature is enabled and set to true. Uncomment below to disable and use IPMI.
 #redfish_inspection=false
 
-# (Optional) Modify files on the node filesystems, you can augment the "fake" roots for the 
+# (Optional) Modify files on the node filesystems, you can augment the "fake" roots for the
 # control plane and worker nodes.
 # If defined, playbook will look for files in control plane and worker subdirectories.
 # Otherwise, it will look in {{ role_path }}/files/customize_filesystem (default)
@@ -103,8 +103,8 @@ prov_ip=172.22.0.3
 # There are two folders manifests/ and openshift/
 # If defined, the playbook will copy manifests from the user provided directory.
 # Otherwise, files will be copied from the default location 'roles/installer/files/manifests/*'
-#customize_extramanifests_path="/path/to/extra/manifests
-#customize_extramanifestsopenshift_path="/path/to/extra/openshift
+#customize_extramanifests_path="/path/to/extra/manifests"
+#customize_extramanifestsopenshift_path="/path/to/extra/openshift"
 
 ######################################
 # Vars regarding install-config.yaml #
@@ -155,7 +155,7 @@ pullsecret=""
 #provisioningHostIP=<baremetal_net_IP1>
 #bootstrapProvisioningIP=<baremetal_net_IP2>
 
-# (Optional) Change the boot mode of the OpenShift cluster nodes to legacy mode (BIOS). Default is UEFI. 
+# (Optional) Change the boot mode of the OpenShift cluster nodes to legacy mode (BIOS). Default is UEFI.
 #bootmode=legacy
 
 # Master nodes

--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -100,9 +100,11 @@ prov_ip=172.22.0.3
 #customize_node_filesystems="/path/to/customized/filesystems"
 
 # (Optional) Modify the path to add external manifests to the deployed nodes.
+# There are two folders manifests/ and openshift/
 # If defined, the playbook will copy manifests from the user provided directory.
 # Otherwise, files will be copied from the default location 'roles/installer/files/manifests/*'
 #customize_extramanifests_path="/path/to/extra/manifests
+#customize_extramanifestsopenshift_path="/path/to/extra/openshift
 
 ######################################
 # Vars regarding install-config.yaml #

--- a/ansible-ipi-install/roles/installer/tasks/50_extramanifests.yml
+++ b/ansible-ipi-install/roles/installer/tasks/50_extramanifests.yml
@@ -1,4 +1,18 @@
 ---
+- name: Check if override path is defined for extra openshift manifests
+  set_fact:
+    extramanifestsopenshift_path: "{{ customize_extramanifestsopenshift_path | default( 'roles/installer/files/openshift/*' ) }}"
+
+- name: Add Manifests from files dir
+  copy:
+    src: "{{ item }}"
+    dest: "{{ dir }}/openshift/"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+  with_fileglob:
+    - "{{ extramanifestsopenshift_path }}"
+  tags: extramanifests
+
 - name: Check if override path is defined for extramanifests
   set_fact:
     extramanifests_path: "{{ customize_extramanifests_path | default( 'roles/installer/files/manifests/*' ) }}"
@@ -6,7 +20,7 @@
 - name: Add Manifests from files dir
   copy:
     src: "{{ item }}"
-    dest: "{{ dir }}/openshift/"
+    dest: "{{ dir }}/manifests/"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
   with_fileglob:

--- a/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
+++ b/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
@@ -109,9 +109,11 @@ prov_ip=172.22.0.3
 #customize_node_filesystems="/path/to/customized/filesystems"
 
 # (Optional) Modify the path to add external manifests to the deployed nodes.
+# There are two folders manifests/ and openshift/
 # If defined, the playbook will copy manifests from the user provided directory.
 # Otherwise, files will be copied from the default location 'roles/installer/files/manifests/*'
 #customize_extramanifests_path="/path/to/extra/manifests
+#customize_extramanifestsopenshift_path="/path/to/extra/openshift
 
 ######################################
 # Vars regarding install-config.yaml #

--- a/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
+++ b/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
@@ -101,7 +101,7 @@ prov_ip=172.22.0.3
 # By default this feature is enabled and set to true. Uncomment below to disable and use IPMI.
 #redfish_inspection=false
 
-# (Optional) Modify files on the node filesystems, you can augment the "fake" roots for the 
+# (Optional) Modify files on the node filesystems, you can augment the "fake" roots for the
 # control plane and worker nodes.
 # If defined, playbook will look for files in control plane and worker subdirectories.
 # Otherwise, it will look in {{ role_path }}/files/customize_filesystem (default)
@@ -112,8 +112,8 @@ prov_ip=172.22.0.3
 # There are two folders manifests/ and openshift/
 # If defined, the playbook will copy manifests from the user provided directory.
 # Otherwise, files will be copied from the default location 'roles/installer/files/manifests/*'
-#customize_extramanifests_path="/path/to/extra/manifests
-#customize_extramanifestsopenshift_path="/path/to/extra/openshift
+#customize_extramanifests_path="/path/to/extra/manifests"
+#customize_extramanifestsopenshift_path="/path/to/extra/ogpenshift"
 
 ######################################
 # Vars regarding install-config.yaml #


### PR DESCRIPTION
# Description

Currently the playbooks only support customizing the assets in the openshift folder. This PR will allow customizing the `manifests` folder as well

Fixes #683 

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Run the playbooks with customization

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [X] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [X] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [X] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [X] PRs should not be merged unless positively reviewed.
