### PR TITLE
Restored the content for Fujitsu iRMC.

### DIFF
--- a/documentation/ipi-install/ipi-install-configuration-files.adoc
+++ b/documentation/ipi-install/ipi-install-configuration-files.adoc
@@ -1,7 +1,7 @@
 [id="ipi-install-configuration-files"]
 = Configuration files
 :context: ipi-install-configuration-files
-//:release: 4.6
+//:release: 4.7
 
 
 include::modules/ipi-install-configuring-the-install-config-file.adoc[leveloffset=+1]
@@ -15,6 +15,10 @@ include::modules/ipi-install-additional-install-config-parameters.adoc[leveloffs
 include::modules/ipi-install-bmc-addressing-for-dell.adoc[leveloffset=+1]
 
 include::modules/ipi-install-bmc-addressing-for-hpe.adoc[leveloffset=+1]
+
+ifeval::[{release} > 4.7]
+include::modules/ipi-install-bmc-addressing-for-fujitsu.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/ipi-install-root-device-hints.adoc[leveloffset=+1]
 

--- a/documentation/ipi-install/modules/ipi-install-bmc-addressing-for-fujitsu.adoc
+++ b/documentation/ipi-install/modules/ipi-install-bmc-addressing-for-fujitsu.adoc
@@ -1,0 +1,72 @@
+// This is included in the following assemblies:
+//
+// ipi-install-configuration-files.adoc
+[id='bmc-addressing-for-fujitsu_{context}']
+
+= BMC addressing for Fujitsu
+
+The `address` field for each `bmc` entry is a URL for connecting to the {product-title} cluster nodes, including the type of controller in the URL scheme and its location on the network.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    hosts:
+      - name: <host name>
+        role: <master | worker>
+        bmc:
+          address: <address>
+          username: <user>
+          password: <password>
+----
+
+For Fujitsu hardware, Red Hat supports iRMC and IPMI.
+
+.BMC address formats for Fujitsu hardware
+[frame="topbot",options="header"]
+|====
+|Protocol|Address Format
+|iRMC| `irmc://<out-of-band-ip>`
+|IPMI| `ipmi://<out-of-band-ip>`
+|====
+
+See the following sections for additional details.
+
+.iRMC for Fujitsu
+
+Fujitsu nodes can use `irmc://<out-of-band-ip>` and defaults to port `623`. The following example demonstrates an iRMC configuration within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: irmc://<out-of-band-ip>
+          username: <user>
+          password: <password>
+----
+
+.IPMI
+
+Hosts using IPMI use the `ipmi://<out-of-band-ip>:<port>` address format, which defaults to port `623` if not specified. The following example demonstrates an IPMI configuration within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: ipmi://<out-of-band-ip>
+          username: <user>
+          password: <password>
+----
+
+[NOTE]
+====
+IPMI does not encrypt communications. It is suitable for use within a data center over a secured network.
+====


### PR DESCRIPTION
# Description

Restored the content for Fujitsu iRMC. It is within its own module per restructuring of BMC docs. https://issues.redhat.com/browse/TELCODOCS-111?filter=-1

Fixes: telcodocs-111

Signed-off-by: John Wilkins <jowilkin@redhat.com>
@iranzo 

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This change is a documentation update