### PR TITLE
Minor changes to Secure Boot for telcodocs-204.

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-configuring-nodes.adoc
+++ b/documentation/ipi-install/modules/ipi-install-configuring-nodes.adoc
@@ -63,13 +63,13 @@ endif::[]
 ifeval::[{release} > 4.6]
 .Configuring nodes for Secure Boot
 
-Secure Boot prevents a node from booting unless it verifies the node is using only trusted software, such as UEFI firmware drivers, EFI applications and the operating system. Red Hat only supports Secure Boot when deploying with RedFish Virtual Media.
+Secure Boot prevents a node from booting unless it verifies the node is using only trusted software, such as UEFI firmware drivers, EFI applications and the operating system. Red Hat only supports Secure Boot when deploying with Redfish virtual media.
 
 To enable Secure Boot, refer to the hardware guide for the node. To enable Secure Boot, execute the following:
 
 . Boot the node and enter the BIOS menu.
-. Set the node's boot mode to UEFI Enabled.
-. Enable Secure Boot.
+. Set the node's boot mode to "UEFI secure boot".
+. Set Secure Boot to `TRUE` before deployment.
 +
 [IMPORTANT]
 ====

--- a/documentation/ipi-install/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/documentation/ipi-install/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -5,9 +5,9 @@
 [id='ipi-install-firmware-requirements-for-installing-with-virtual-media_{context}']
 = Firmware requirements for installing with virtual media
 
-The installer for installer-provisioned {product-title} clusters validates the hardware and firmware compatibility with RedFish virtual media. The following table lists supported firmware for installer-provisioned {product-title} clusters deployed with RedFish virtual media.
+The installer for installer-provisioned {product-title} clusters validates the hardware and firmware compatibility with Redfish virtual media. The following table lists supported firmware for installer-provisioned {product-title} clusters deployed with Redfish virtual media.
 
-.Firmware Compatibility for RedFish Virtual Media
+.Firmware compatibility for Redfish virtual media
 [frame="topbot", options="header"]
 |====
 |Hardware| Model | Management | Minimum Firmware Version

--- a/documentation/ipi-install/modules/ipi-install-node-requirements.adoc
+++ b/documentation/ipi-install/modules/ipi-install-node-requirements.adoc
@@ -8,34 +8,34 @@ Secure Boot// Module included in the following assemblies:
 
 Installer-provisioned installation involves a number of hardware node requirements:
 
-- **CPU architecture:** All nodes must use `x86_64` CPU architecture.
+- *CPU architecture:* All nodes must use `x86_64` CPU architecture.
 
-- **Similar nodes:** Red Hat recommends nodes have an identical configuration per role. That is, Red Hat recommends nodes be the same brand and model with the same CPU, memory and storage configuration.
+- *Similar nodes:* Red Hat recommends nodes have an identical configuration per role. That is, Red Hat recommends nodes be the same brand and model with the same CPU, memory and storage configuration.
 
 ifeval::[{release} < 4.5]
-- **Intelligent Platform Management Interface (IPMI):** Installer-provisioned installation requires IPMI enabled on each node.
+- *Intelligent Platform Management Interface (IPMI):* Installer-provisioned installation requires IPMI enabled on each node.
 endif::[]
 
 ifeval::[{release} > 4.4]
-- **Baseboard Management Controller:** The `provisioner` node must be able to access the baseboard management controller (BMC) of each {product-title} cluster node. You may use IPMI, RedFish, or a proprietary protocol.
+- *Baseboard Management Controller:* The `provisioner` node must be able to access the baseboard management controller (BMC) of each {product-title} cluster node. You may use IPMI, Redfish, or a proprietary protocol.
 endif::[]
 
-- **Latest generation:** Nodes must be of the most recent generation. Installer-provisioned installation relies on BMC protocols, which must be compatible across nodes. Additionally, {op-system-base} 8 ships with the most recent drivers for RAID controllers. Ensure that the nodes are recent enough to support {op-system-base} 8 for the `provisioner` node and {op-system} 8 for the control plane and worker nodes.
+- *Latest generation:* Nodes must be of the most recent generation. Installer-provisioned installation relies on BMC protocols, which must be compatible across nodes. Additionally, {op-system-base} 8 ships with the most recent drivers for RAID controllers. Ensure that the nodes are recent enough to support {op-system-base} 8 for the `provisioner` node and {op-system} 8 for the control plane and worker nodes.
 
-- **Registry node:** (Optional) If setting up a disconnected mirrored registry, it is recommended the registry reside in its own node.
+- *Registry node:* (Optional) If setting up a disconnected mirrored registry, it is recommended the registry reside in its own node.
 
-- **Provisioner node:** Installer-provisioned installation requires one `provisioner` node.
+- *Provisioner node:* Installer-provisioned installation requires one `provisioner` node.
 
-- **Control plane:** Installer-provisioned installation requires three control plane nodes for high availability.
+- *Control plane:* Installer-provisioned installation requires three control plane nodes for high availability.
 
-- **Worker nodes:** While not required, a typical production cluster has one or more worker nodes. Smaller clusters are more resource efficient for administrators and developers during development, production, and testing.
+- *Worker nodes:* While not required, a typical production cluster has one or more worker nodes. Smaller clusters are more resource efficient for administrators and developers during development, production, and testing.
 
-- **Network interfaces:** Each node must have at least one 10GB network interface for the routable `baremetal` network. Each node must have one 10GB network interface for a `provisioning` network *when using the `provisioning` network* for deployment. Using the `provisioning` network is the default configuration. Network interface names must follow the same naming convention across all nodes. For example, the first NIC name on a node, such as `eth0` or `eno1`, must be the same name on all of the other nodes. The same principle applies to the remaining NICs on each node.
+- *Network interfaces:* Each node must have at least one 10GB network interface for the routable `baremetal` network. Each node must have one 10GB network interface for a `provisioning` network *when using the `provisioning` network* for deployment. Using the `provisioning` network is the default configuration. Network interface names must follow the same naming convention across all nodes. For example, the first NIC name on a node, such as `eth0` or `eno1`, must be the same name on all of the other nodes. The same principle applies to the remaining NICs on each node.
 
 ifeval::[{release} > 4.3]
-- **Unified Extensible Firmware Interface (UEFI):** Installer-provisioned installation requires UEFI boot on all {product-title} nodes when using IPv6 addressing on the `provisioning` network. In addition, UEFI Device PXE Settings must be set to use the IPv6 protocol on the `provisioning` network NIC, but *omitting the `provisioning` network removes this requirement.*
+- *Unified Extensible Firmware Interface (UEFI):* Installer-provisioned installation requires UEFI boot on all {product-title} nodes when using IPv6 addressing on the `provisioning` network. In addition, UEFI Device PXE Settings must be set to use the IPv6 protocol on the `provisioning` network NIC, but omitting the `provisioning` network removes this requirement.
 endif::[]
 
 ifeval::[{release} > 4.6]
-- **Secure Boot:** Many production scenarios require nodes with Secure Boot enabled to verify the node only boots with trusted software, such as UEFI firmware drivers, EFI applications and the operating system. To deploy a {product-title} cluster with Secure Boot, you must enable UEFI boot mode and Secure Boot on each control plane node and each worker node. Red Hat supports Secure Boot **only** when installer-provisioned installation uses Red Fish Virtual Media. Red Hat **does not** support Secure Boot with self-generated keys.
+- *Secure Boot:* Many production scenarios require nodes with Secure Boot enabled to verify the node only boots with trusted software, such as UEFI firmware drivers, EFI applications and the operating system. To deploy a {product-title} cluster with Secure Boot, you must enable UEFI boot mode and Secure Boot on each control plane node and each worker node. Red Hat supports Secure Boot only when installer-provisioned installation uses Redfish virtual media. Red Hat does not support Secure Boot with self-generated keys. Red Hat supports Secure Boot on 10th generation HPE hardware and 9th generation Dell hardware running firmware version `2.75.75.75` or greater.
 endif::[]


### PR DESCRIPTION
Fixes: telcodocs-204

Signed-off-by: John Wilkins <jowilkin@redhat.com>

@iranzo
@rlopez133 

# Description

There are minor changes to the Secure Boot docs to accommodate https://issues.redhat.com/browse/TELCODOCS-204 and parent epic https://issues.redhat.com/browse/KNIDEPLOY-4232. Also, OCP prefers *bold* in single asterisks, so there are a few changes there too.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This change is a documentation update