### PR TITLE
Added a main.adoc file for local builds with asciidoctor

### DIFF
--- a/documentation/ipi-install/main.adoc
+++ b/documentation/ipi-install/main.adoc
@@ -1,0 +1,26 @@
+//local build
+
+[id="ipi-install-main"]
+= Deploying Installer Provisioned Infrastructure (IPI) on Bare Metal
+
+:imagesdir: images
+:context: ipi-install-installation-workflow
+:release: 4.7
+:upstream:
+:product-title: OpenShift Container Platform
+:op-system-first: Red Hat Enterprise Linux CoreOS (RHCOS)
+:op-system: RHCOS
+
+// Deploying IPI Baremetal
+include::ipi-install-overview.adoc[leveloffset=+1]
+
+// Prerequisites
+include::ipi-install-prerequisites.adoc[leveloffset=+1]
+
+// Installation Workflow
+include::ipi-install-installation-workflow.adoc[leveloffset=+1]
+
+//Day 2
+include::ipi-install-expanding-the-cluster.adoc[leveloffset=+1]
+
+include::ipi-install-troubleshooting.adoc[leveloffset=+1]


### PR DESCRIPTION
Signed-off-by: John Wilkins <jowilkin@redhat.com>
@iranzo 

# Description

I've created a main.adoc file that is only applicable for writers building docs on local machines using asciidoctor. There are issues with the netlify upstream master file when running with asciidoctor. This has no impact on building upstream or downstream docs. 

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This change is a documentation update

