### PR TITLE
First draft of NTP server requirements for 4.8.

### DIFF
--- a/documentation/ipi-install/ipi-install-post-installation-configuration.adoc
+++ b/documentation/ipi-install/ipi-install-post-installation-configuration.adoc
@@ -1,0 +1,8 @@
+[id="ipi-install-post-installation-configuration"]
+= Post-installation Configuration
+include::modules/common-attributes.adoc[]
+:context: ipi-install-post-installation-configuration
+
+After successfully deploying an installer-provisioned cluster, consider the following post-install procedures.
+
+include::modules/ipi-install-configuring-ntp.adoc[leveloffset=+1]

--- a/documentation/ipi-install/ipi-install-upstream-master.adoc
+++ b/documentation/ipi-install/ipi-install-upstream-master.adoc
@@ -55,6 +55,11 @@ include::ipi-install-prerequisites.adoc[leveloffset=+1]
 // Installation Workflow
 include::ipi-install-installation-workflow.adoc[leveloffset=+1]
 
+//Post installation configuration.
+ifeval::[{release}>4.7]
+include::ipi-install-post-installation-configuration.adoc[leveloffset=+1]
+endif::[]
+
 
 // Backing up the cluster configuration
 ifndef::upstream[]

--- a/documentation/ipi-install/main.adoc
+++ b/documentation/ipi-install/main.adoc
@@ -5,7 +5,7 @@
 
 :imagesdir: images
 :context: ipi-install-installation-workflow
-:release: 4.7
+:release: 4.8
 :upstream:
 :product-title: OpenShift Container Platform
 :op-system-first: Red Hat Enterprise Linux CoreOS (RHCOS)
@@ -19,6 +19,11 @@ include::ipi-install-prerequisites.adoc[leveloffset=+1]
 
 // Installation Workflow
 include::ipi-install-installation-workflow.adoc[leveloffset=+1]
+
+//Post installation configuration.
+ifeval::[{release} > 4.7]
+include::ipi-install-post-installation-configuration.adoc[leveloffset=+1]
+endif::[]
 
 //Day 2
 include::ipi-install-expanding-the-cluster.adoc[leveloffset=+1]

--- a/documentation/ipi-install/modules/ipi-install-configuring-ntp.adoc
+++ b/documentation/ipi-install/modules/ipi-install-configuring-ntp.adoc
@@ -1,0 +1,219 @@
+// This is included in the following assemblies:
+//
+// ipi-install-post-installation-configuration.adoc
+[id='configuring-ntp_{context}']
+
+= Configuring NTP
+
+After successfully deploying an installer-provisioned cluster, configure NTP. {product-title} 4.8 and later releases install NTP server on the control plane nodes. Worker nodes retrieve the date and time from the NTP servers on the control plane nodes. This configuration approach enables installation of clusters connected to a routable network with access to upstream NTP servers and clusters not connected to a routable network that don't have access to upstream NTP servers.
+
+.Procedure
+
+. Create a `~/control-plane-chrony.conf` file for the control plane nodes.
++
+[source,bash]
+----
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (https://www.pool.ntp.org/join.html).
+
+# This file is managed by the machine config operator
+server openshift-master-0.<cluster-name>.<domain> iburst <1>
+server openshift-master-1.<cluster-name>.<domain> iburst
+server openshift-master-2.<cluster-name>.<domain> iburst
+
+stratumweight 0
+driftfile /var/lib/chrony/drift
+rtcsync
+makestep 10 3
+bindcmdaddress 127.0.0.1
+bindcmdaddress ::1
+keyfile /etc/chrony.keys
+commandkey 1
+generatecommandkey
+noclientlog
+logchange 0.5
+logdir /var/log/chrony
+
+# Configure the control plane nodes to serve as local NTP servers
+# for all worker nodes, even if they are not in sync with an
+# upstream NTP server.
+
+# Allow NTP client access from the local network.
+allow all
+# Serve time even if not synchronized to a time source.
+local stratum 3 orphan
+----
++
+Where:
++
+<1> You must replace `<cluster-name>` with the name of the cluster and replace `<domain>` with the fully-qualified domain name.
+
+. Create a `~/worker-chrony.conf` file for the worker nodes such that worker nodes reference the NTP servers on the control plane nodes.
++
+[source,bash]
+----
+# This file is managed by the machine config operator
+server openshift-master-0.<cluster-name>.<domain> iburst <1>
+server openshift-master-1.<cluster-name>.<domain> iburst
+server openshift-master-2.<cluster-name>.<domain> iburst
+
+stratumweight 0
+driftfile /var/lib/chrony/drift
+rtcsync
+makestep 10 3
+bindcmdaddress 127.0.0.1
+bindcmdaddress ::1
+keyfile /etc/chrony.keys
+commandkey 1
+generatecommandkey
+noclientlog
+logchange 0.5
+logdir /var/log/chrony
+----
++
+Where:
++
+<1> You must replace `<cluster-name>` with the name of the cluster and replace `<domain>` with the fully-qualified domain name.
+
+. Create a `~/ntp-server.yaml` file for telling the Machine Configuration Operator to apply the `~/control-plane-chrony.conf` settings to the NTP servers on the control plane nodes.
++
+[source,bash]
+----
+# This example MachineConfig replaces ~/control-plane-chrony.conf
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-master-etc-chrony-conf-override-to-server
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+        - contents:
+            source: data:text/plain;charset=utf-8;base64,BASE64ENCODEDCONFIGFILE<1>
+          filesystem: root
+          mode: 0644
+          path: /etc/control-plane-chrony.conf
+----
++
+Where:
++
+<1> You must replace the `BASE64ENCODEDCONFIGFILE` string with the base64 encoded string of the `~/control-plane-chrony.conf` file in the subsequent step.
+
+. Generate a base64 string of the `~/control-plane-chrony.conf` file.
++
+[source,bash]
+----
+$ base64 ~/control-plane-chrony.conf
+----
++
+The output will look something like this:
++
+[source,bash]
+----
+IyBVc2UgcHVibGljIHNlcnZlcnMgZnJvbSB0aGUgcG9vbC5udHAub3JnIHByb2plY3QuCiMgUGxl
+YXNlIGNvbnNpZGVyIGpvaW5pbmcgdGhlIHBvb2wgKGh0dHBzOi8vd3d3LnBvb2wubnRwLm9yZy9q
+b2luLmh0bWwpLgoKIyBUaGlzIGZpbGUgaXMgbWFuYWdlZCBieSB0aGUgbWFjaGluZSBjb25maWcg
+b3BlcmF0b3IKc2VydmVyIG9wZW5zaGlmdC1tYXN0ZXItMC48Y2x1c3Rlci1uYW1lPi48ZG9tYWlu
+PiBpYnVyc3QKc2VydmVyIG9wZW5zaGlmdC1tYXN0ZXItMS48Y2x1c3Rlci1uYW1lPi48ZG9tYWlu
+PiBpYnVyc3QKc2VydmVyIG9wZW5zaGlmdC1tYXN0ZXItMi48Y2x1c3Rlci1uYW1lPi48ZG9tYWlu
+PiBpYnVyc3QKCnN0cmF0dW13ZWlnaHQgMApkcmlmdGZpbGUgL3Zhci9saWIvY2hyb255L2RyaWZ0
+CnJ0Y3N5bmMKbWFrZXN0ZXAgMTAgMwpiaW5kY21kYWRkcmVzcyAxMjcuMC4wLjEKYmluZGNtZGFk
+ZHJlc3MgOjoxCmtleWZpbGUgL2V0Yy9jaHJvbnkua2V5cwpjb21tYW5ka2V5IDEKZ2VuZXJhdGVj
+b21tYW5ka2V5Cm5vY2xpZW50bG9nCmxvZ2NoYW5nZSAwLjUKbG9nZGlyIC92YXIvbG9nL2Nocm9u
+eQoKIyBDb25maWd1cmUgdGhlIGNvbnRyb2wgcGxhbmUgbm9kZXMgdG8gc2VydmUgYXMgbG9jYWwg
+TlRQIHNlcnZlcnMKIyBmb3IgYWxsIHdvcmtlciBub2RlcywgZXZlbiBpZiB0aGV5IGFyZSBub3Qg
+aW4gc3luYyB3aXRoIGFuCiMgdXBzdHJlYW0gTlRQIHNlcnZlci4KCiMgQWxsb3cgTlRQIGNsaWVu
+dCBhY2Nlc3MgZnJvbSB0aGUgbG9jYWwgbmV0d29yay4KYWxsb3cgYWxsCiMgU2VydmUgdGltZSBl
+dmVuIGlmIG5vdCBzeW5jaHJvbml6ZWQgdG8gYSB0aW1lIHNvdXJjZS4KbG9jYWwgc3RyYXR1bSAz
+IG9ycGhhbgo=
+----
++
+Replace the `BASE64ENCODEDCONFIGFILE` string in the `~/ntp-server.yaml` with the base64 encoded string.
+
+. Apply the `ntp-server.yaml` policy to the control plane nodes.
++
+[source,bash]
+----
+$ oc apply -f ~/ntp-server.yaml
+----
++
+[source,bash]
+----
+machineconfig.machineconfiguration.openshift.io/99-master-etc-chrony-conf-override-for-server created
+----
+
+. Create a `~/ntp-client.yaml` file for telling the Machine Configuration Operator to apply the `~/worker-chrony.conf` settings to the NTP clients on the worker nodes.
++
+[source,bash]
+----
+# This example MachineConfig replaces ~/worker-chrony.conf
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-master-etc-chrony-conf-override-for-worker
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+        - contents:
+            source: data:text/plain;charset=utf-8;base64,BASE64ENCODEDCONFIGFILE<1>
+          filesystem: root
+          mode: 0644
+          path: /etc/worker-chrony.conf
+----
++
+Where:
++
+<1> You must replace the `BASE64ENCODEDCONFIGFILE` string with the base64 encoded string of the `~/worker-chrony.conf` file in the subsequent step.
+
+
+. Generate a base64 encoded string of the `~/worker-chrony.conf` file.
++
+[source,bash]
+----
+$ base64 ~/worker-chrony.conf
+----
++
+The output will looks something like this:
++
+[source,bash]
+----
+IyBUaGlzIGZpbGUgaXMgbWFuYWdlZCBieSB0aGUgbWFjaGluZSBjb25maWcgb3BlcmF0b3IKc2Vy
+dmVyIG9wZW5zaGlmdC1tYXN0ZXItMC48Y2x1c3Rlci1uYW1lPi48ZG9tYWluPiBpYnVyc3QKc2Vy
+dmVyIG9wZW5zaGlmdC1tYXN0ZXItMS48Y2x1c3Rlci1uYW1lPi48ZG9tYWluPiBpYnVyc3QKc2Vy
+dmVyIG9wZW5zaGlmdC1tYXN0ZXItMi48Y2x1c3Rlci1uYW1lPi48ZG9tYWluPiBpYnVyc3QKCnN0
+cmF0dW13ZWlnaHQgMApkcmlmdGZpbGUgL3Zhci9saWIvY2hyb255L2RyaWZ0CnJ0Y3N5bmMKbWFr
+ZXN0ZXAgMTAgMwpiaW5kY21kYWRkcmVzcyAxMjcuMC4wLjEKYmluZGNtZGFkZHJlc3MgOjoxCmtl
+eWZpbGUgL2V0Yy9jaHJvbnkua2V5cwpjb21tYW5ka2V5IDEKZ2VuZXJhdGVjb21tYW5ka2V5Cm5v
+Y2xpZW50bG9nCmxvZ2NoYW5nZSAwLjUKbG9nZGlyIC92YXIvbG9nL2Nocm9ueQo=
+----
++
+Replace the `BASE64ENCODEDCONFIGFILE` string in the `~/ntp-client.yaml` file with the base64 encoded string.
+
+
+. Apply the `~/ntp-client.yaml` policy to the worker nodes.
++
+[source,bash]
+----
+$ oc apply -f ~/worker-chrony.conf
+----
++
+[source,bash]
+----
+machineconfig.machineconfiguration.openshift.io/99-master-etc-chrony-conf-override-for-worker created
+----
+
+. Check the status of the applied NTP settings.
++
+[source,bash]
+----
+$ oc describe machineconfigpool
+----

--- a/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
+++ b/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
@@ -9,7 +9,23 @@ Installer-provisioned installation of {product-title} involves several network r
 
 .Network Time Protocol (NTP)
 
+ifeval::[{release} <= 4.7]
 Each {product-title} node in the cluster must have access to an NTP server.
+endif::[]
+
+ifeval::[{release}> 4.7]
+{product-title} nodes use NTP to synchronize clocks. For example, cluster nodes use SSL certificates that require validation, which might fail if the date and time between the nodes are not in sync.
+
+[IMPORTANT]
+====
+Define a consistent clock date and time format in each cluster node's BIOS settings, or installation will fail.
+====
+
+In {product-title} 4.8 and later releases, the cluster deploys with NTP servers on the control plane nodes. The worker nodes must reference the NTP servers of the control plane nodes. Using this configuration, system administrators can deploy a {product-title} cluster whether it is connected to a routable network or not.
+
+//image::file name[alt text description] <--insert image from Jess
+endif::[]
+
 
 .Configuring NICs
 


### PR DESCRIPTION
Signed-off-by: John Wilkins <jowilkin@redhat.com>

# Description

First draft of NTP server requirements for 4.8 based on Pablo's blog: https://iranzo.io/blog/2020/12/07/configuring-openshift-with-self-contained-ntp/

@iranzo 

https://issues.redhat.com/browse/KNIDEPLOY-3613
https://issues.redhat.com/browse/TELCODOCS-115

Fixes: TELCODOCS-115, KNIDEPLOY-3613

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This change is a documentation update

