### PR TITLE
adding instructions on how to get the value for UPSTREAM_REPO

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-creating-a-disconnected-registry.adoc
+++ b/documentation/ipi-install/modules/ipi-install-creating-a-disconnected-registry.adoc
@@ -187,8 +187,9 @@ Replace `<username>` with the user name and `<passwd>` with the password.
 . Get the release image and mirror the remote install images to the local repository.
 +
 [source,terminal]
+[subs="attributes"]
 ----
-[user@registry ~]$ VERSION=latest-4.6
+[user@registry ~]$ export VERSION=latest-{release}
 [user@registry ~]$ UPSTREAM_REPO=$(curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$VERSION/release.txt | awk  '/Pull From/ {print $3}')
 [user@registry ~]$ /usr/local/bin/oc adm release mirror \
   -a pull-secret-update.txt

--- a/documentation/ipi-install/modules/ipi-install-creating-a-disconnected-registry.adoc
+++ b/documentation/ipi-install/modules/ipi-install-creating-a-disconnected-registry.adoc
@@ -184,10 +184,12 @@ Replace `<username>` with the user name and `<passwd>` with the password.
 [user@registry ~]$ sudo scp kni@provisioner:/usr/local/bin/oc /usr/local/bin
 ----
 
-. Mirror the remote install images to the local repository.
+. Get the release image and mirror the remote install images to the local repository.
 +
 [source,terminal]
 ----
+[user@registry ~]$ VERSION=latest-4.6
+[user@registry ~]$ UPSTREAM_REPO=$(curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$VERSION/release.txt | awk  '/Pull From/ {print $3}')
 [user@registry ~]$ /usr/local/bin/oc adm release mirror \
   -a pull-secret-update.txt
   --from=$UPSTREAM_REPO \


### PR DESCRIPTION
# Description

The instructions for the disconnected registry reference an `UPSTREAM_REPO` variable, but does not explain how to generate it.
Fixes #708 

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran through commands to successfully deploy a secured disconnected registry

**Test Configuration**:

- Versions: 4.6.16, 4.6.23
- Hardware: VM

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
