### PR TITLE
Set a "Subject Alternate Names" when securing disconnected registry

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-creating-a-disconnected-registry.adoc
+++ b/documentation/ipi-install/modules/ipi-install-creating-a-disconnected-registry.adoc
@@ -75,6 +75,7 @@ Generate a self-signed certificate for the registry node and put it in the `/opt
     -x509 \
     -days 365 \
     -out /opt/registry/certs/domain.crt \
+    -addext "subjectAltName = DNS:${host_fqdn}" \
     -subj "/C=${cert_c}/ST=${cert_s}/L=${cert_l}/O=${cert_o}/OU=${cert_ou}/CN=${cert_cn}"
 ----
 +


### PR DESCRIPTION
# Description

This change adds a subjectAltName to the self-signed certificate generated for the disconnected registry.

Fixes #710 

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Successfully deployed disconnected registry once a subjectAltName was used in my cert
- [ ] Test B

**Test Configuration**:

- Versions: 4.6.16, 4.6.23
- Hardware: VM

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
