### PR TITLE
Adding missing wildcard under dnsmasq for ipv6

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-upstream-creating-dhcp-reservations-using-dnsmasq-option2.adoc
+++ b/documentation/ipi-install/modules/ipi-install-upstream-creating-dhcp-reservations-using-dnsmasq-option2.adoc
@@ -102,7 +102,7 @@ log-dhcp
 domain=openshift.example.com,<baremetal-IPv6-cidr>,local
 
 # static host-records
-address=/apps.openshift.example.com/<wildcard-ingress-lb-ip>
+address=/.apps.openshift.example.com/<wildcard-ingress-lb-ip>
 host-record=api.openshift.example.com,<api-ip>
 host-record=ns1.openshift.example.com,<dns-ip>
 host-record=openshift-master-0.openshift.example.com,<ip-of-openshift-master-0>


### PR DESCRIPTION
# Description

Adding a wildcard entry for dnsmasq under ipv6.

## Type of change

Please select the appropriate options:
- [x ] This change is a documentation update

## Checklist

- [x ] I have performed a self-review of my own code
- [x ] PRs should not be merged unless positively reviewed.
