### PR TITLE
Content for telcodocs-216-fix

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc
+++ b/documentation/ipi-install/modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc
@@ -79,7 +79,20 @@ spec:
           filesystem: root
           mode: 420
           path: /etc/kubernetes/manifests/coredns.yaml
----
+----
++
+This manifest will place the `apiVIP` and `ingressVIP` virtual IP addresses on the control plane nodes. Additionally, the following processes will deploy on the control plane nodes only:
++
+* `openshift-ingress-operator`
++
+* `keepalived`
+
+. Save the `cluster-network-avoid-workers-99-config.yaml` file.
+
+. Create a `manifests/cluster-ingress-default-ingresscontroller.yaml` file.
++
+[source,yaml]
+----
 apiVersion: operator.openshift.io/v1
 kind: IngressController
 metadata:
@@ -91,14 +104,6 @@ spec:
       matchLabels:
         node-role.kubernetes.io/master: ""
 ----
-+
-This manifest will place the `apiVIP` and `ingressVIP` virtual IP addresses on the control plane nodes. Additionally, the following processes will deploy on the control plane nodes only:
-+
-* `openshift-ingress-operator`
-+
-* `keepalived`
-
-. Save the `cluster-network-avoid-workers-99-config.yaml` file and quit the text editor.
 
 . Consider backing up the `manifests` directory. The installer deletes the `manifests/` directory when creating the cluster.
 


### PR DESCRIPTION
This is a fix discovered during testing. IngressController has to be in a separate manifest file.

Fixes: telcodocs-216

See https://issues.redhat.com/browse/telcodocs-216 for additional details.
@iranzo 
Signed-off-by: John Wilkins <jowilkin@redhat.com>
