### PR TITLE
Changes for KNIDEPLOY-2111

### DIFF
--- a/documentation/ipi-install/ipi-install-expanding-the-cluster.adoc
+++ b/documentation/ipi-install/ipi-install-expanding-the-cluster.adoc
@@ -13,4 +13,6 @@ Expanding the cluster using RedFish Virtual Media involves meeting minimum firmw
 
 include::modules/ipi-install-preparing-the-bare-metal-node.adoc[leveloffset=+1]
 
+include::modules/ipi-install-diagnosing-duplicate-mac-address.adoc[leveloffset=+2]
+
 include::modules/ipi-install-provisioning-the-bare-metal-node.adoc[leveloffset=+1]

--- a/documentation/ipi-install/modules/ipi-install-diagnosing-duplicate-mac-address.adoc
+++ b/documentation/ipi-install/modules/ipi-install-diagnosing-duplicate-mac-address.adoc
@@ -1,0 +1,47 @@
+[id="ipi-install-diagnosing-duplicate-mac-address_{context}"]
+= Diagnosing a duplicate MAC address when provisioning a new host in the cluster
+
+[role="_abstract"]
+If the MAC address of an existing bare metal node in the cluster matches the MAC address of a bare metal host that you are attempting to add to the cluster, the Ironic installation Operator associates the bare metal host with the existing node. If the host enrollment, inspection, cleaning, or other Ironic steps fail, the `metal3-baremetal-operator` continuously retries the install. The Operator displays a registration error for the failed bare metal host. You can diagnose a duplicate MAC address by examining the `metal3-baremetal-operator` log.
+
+.Prerequisites
+
+* Install a {product-title} cluster on bare metal.
+* Install the {product-title} CLI `oc`.
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+To determine whether a bare metal host that fails provisioning has a duplicate MAC address, do the following:
+
+. Get the pods that are running in the `openshift-machine-api`:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-machine-api
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                           READY   STATUS    RESTARTS   AGE
+cluster-autoscaler-operator-77c59896d5-vrc5l   2/2     Running   1          20d
+machine-api-controllers-69d94b9d85-qtrnf       7/7     Running   1          20d
+machine-api-operator-6899f4c5d6-n9zh2          2/2     Running   1          20d
+metal3-7cbcc4b66b-2rkrl                        8/8     Running   0          20d
+----
+
+. Copy the full name of the metal3 pod, for example `metal3-7cbcc4b66b-2rkrl`.
+. Get the `metal3-baremetal-operator` log from the metal3 pod and check if there is a "MAC address already exists" error for the host you are trying to provision:
++
+[source,terminal]
+----
+$ oc -n openshift-machine-api logs metal3-7cbcc4b66b-2rkrl metal3-baremetal-operator
+----
++
+.Example log entry
+[source,terminal]
+----
+... A port with MAC address b4:96:91:1d:7c:20 already exists ...
+----
+

--- a/documentation/ipi-install/modules/ipi-install-preparing-the-bare-metal-node.adoc
+++ b/documentation/ipi-install/modules/ipi-install-preparing-the-bare-metal-node.adoc
@@ -83,6 +83,11 @@ Replace `<num>` for the worker number of the bare metal node in the two `name` f
 +
 Refer to the BMC addressing section for additional BMC configuration options. Replace `<protocol>` with the BMC protocol, such as IPMI, RedFish, or others.
 Replace `<bmc-ip>` with the IP address of the bare metal node's baseboard management controller.
++
+[NOTE]
+====
+If the MAC address of an existing bare metal node matches the MAC address of a bare metal host that you are attempting to provision, then the Ironic installation will fail. If the host enrollment, inspection, cleaning, or other Ironic steps fail, the `metal3-baremetal-operator` will continuously retry. See xref:modules/ipi-install-diagnosing-duplicate-mac-address.adoc#ipi-install-diagnosing-duplicate-mac-address_{context}[Diagnosing a host duplicate MAC address] for more information.
+====
 
 . Create the bare metal node.
 +


### PR DESCRIPTION
# Description

If the MAC address of an existing ironic node and a Bare Metal host matches, then the operator will associate the two. When the host enrollment, inspection, cleaning, or other ironic steps fail, the baremetal-operator will continuously retry. Need to let users know it will retry.

Documents #KNI-2111

## Type of change

Please select the appropriate options:

- [x] This change is a documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
