### PR TITLE
cleanup old bootstrap vm storage

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/59_cleanup_bootstrap.yml
+++ b/ansible-ipi-install/roles/installer/tasks/59_cleanup_bootstrap.yml
@@ -44,16 +44,23 @@
 
 - name: Find old bootstrap VM Storage
   find:
-    paths: "{{ default_libvirt_pool_dir }}"
+    paths: "{{ item }}"
     patterns: '*-bootstrap,*-bootstrap.ign'
+    file_type: directory
   register: find_results
+  with_items: "{{ default_libvirt_pool_dir }}"
   become: yes
   tags: cleanup
 
+- name: Create list of old paths
+  set_fact:
+    vm_paths: "{{ vm_paths  | default([]) + find_results.results[item|int] | json_query('files[*].path') }}"
+  with_sequence: start=0 count={{ default_libvirt_pool_dir | length }}
+
 - name: Delete old bootstrap VMs Storage
   file:
-    path: "{{ item['path'] }}"
+    path: "{{ item }}"
     state: absent
-  loop: "{{ find_results['files'] }}"
+  loop: "{{ vm_paths }}"
   become: yes
   tags: cleanup

--- a/ansible-ipi-install/roles/installer/vars/main.yml
+++ b/ansible-ipi-install/roles/installer/vars/main.yml
@@ -2,7 +2,9 @@
 # vars file for installer
 pullsecret_file: "{{ dir }}/pull-secret.txt"
 cmd: openshift-baremetal-install
-default_libvirt_pool_dir: /var/lib/libvirt/images/
+default_libvirt_pool_dir:
+  - /var/lib/libvirt/images/
+  - /var/lib/libvirt/openshift-images/
 
 # packages needed for the disconnected registry tasks
 packages_registry:


### PR DESCRIPTION
# Description

The [cleanup](https://github.com/openshift-kni/baremetal-deploy/blob/master/ansible-ipi-install/roles/installer/tasks/59_cleanup_bootstrap.yml#L45-L59) tasks to remove all old bootstrap VM storage have been configured to wrong directory. 
Openshift installer uses `/var/lib/libvirt/openshift-images/` to store the images & files, but playbook is configured to clean `/var/lib/libvirt/images/`

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested on a baremetal deployment

**Test Configuration**:

- Versions: OCP 4.7.0, RHEL 8.1, 8.2, 8.3
- Hardware: Any

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
