### PR TITLE
Content for TELCODOCS-128

### DIFF
--- a/documentation/ipi-install/ipi-install-post-installation-configuration.adoc
+++ b/documentation/ipi-install/ipi-install-post-installation-configuration.adoc
@@ -8,3 +8,5 @@ After successfully deploying an installer-provisioned cluster, consider the foll
 include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leveloffset=+1]
 
 include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]
+
+include::modules/nw-enabling-a-provisioning-network-after-installation.adoc[leveloffset=+1]

--- a/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
+++ b/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
@@ -33,14 +33,18 @@ endif::[]
 
 {product-title} deploys with two networks:
 
-- `provisioning`: The `provisioning` network is an *optional* non-routable network used for provisioning the underlying operating system on each node that is a part of the {product-title} cluster. When deploying using the `provisioning` network, the first NIC on each node, such as `eth0` or `eno1`,
-*must* interface with the `provisioning` network.
+- `provisioning`: The `provisioning` network is an *optional* non-routable network used for provisioning the underlying operating system on each node that is a part of the {product-title} cluster. The network interface for the `provisioning` network on each cluster node must have the BIOS or UEFI configured to PXE boot. In {product-title} 4.3, when deploying using the `provisioning` network, the first NIC on each node, such as `eth0` or `eno1`, *must* interface with the `provisioning` network. In {product-title} 4.4 and later releases, you can specify the provisioning network NIC with the `provisioningNetworkInterface` configuration setting.
 
-- `baremetal`: The `baremetal` network is a routable network. When deploying using the `provisioning` network, the second NIC on each node, such as `eth1` or `eno2`, *must* interface with the `baremetal` network. When deploying without a `provisioning` network, you can use any NIC on each node to interface with the `baremetal` network.
+- `baremetal`: The `baremetal` network is a routable network. In {product-title} 4.3, when deploying using the `provisioning` network, the second NIC on each node, such as `eth1` or `eno2`, *must* interface with the `baremetal` network. In {product-title} 4.4 and later releases, you can use any NIC order to interface with the `baremetal` network, provided it is the same NIC order across worker and control plane nodes and not the NIC specified in the `provisioningNetworkInterface` configuration setting for the `provisioning` network.
+
+[NOTE]
+====
+Use a compatible approach such that cluster nodes use the same NIC ordering on all cluster nodes. NICs must have heterogeneous hardware with the same NIC naming convention such as `eth0` or `eno1`.
+====
 
 [IMPORTANT]
 ====
-Each NIC should be on a separate VLAN corresponding to the appropriate network.
+When using a VLAN, each NIC must be on a separate VLAN corresponding to the appropriate network.
 ====
 
 .Configuring the DNS server

--- a/documentation/ipi-install/modules/nw-enabling-a-provisioning-network-after-installation.adoc
+++ b/documentation/ipi-install/modules/nw-enabling-a-provisioning-network-after-installation.adoc
@@ -1,0 +1,77 @@
+// This is included in the following assemblies:
+//
+// ipi-install-post-installation-configuration.adoc
+
+[id="enabling-a-provisioning-network-after-installation_{context}"]
+
+= Enabling a provisioning network after installation
+
+The assisted installer and installer-provisioned installation for bare metal clusters provide the ability to deploy a cluster without a `provisioning` network. This capability is for scenarios such as proof-of-concept clusters or deploying exclusively with Redfish virtual media when each node's baseboard management controller is routable via the `baremetal` network.
+
+In {product-title} 4.8 and later, you can enable a `provisioning` network after installation using the cluster baremetal operator (CBO).
+
+.Prerequisites
+
+. The `provisioning` network must exist.
+. The `provisioning` network must be enabled.
+. The cluster nodes must be connected to the `provisioning` network using the same network interface on both worker nodes and control plane nodes.
+. The cluster nodes must be homogeneous. If the cluster nodes use different network interface names for the same network interface order, such as `eth0` and `eno1` for the first network interface, the procedure will fail.
+
+.Procedure
+
+. Identify the provisioning interface name for the cluster nodes. For example, `eth0` or `eno1`.
+
+. Enable the preboot execution environment (PXE) on the `provisioning` network interface of the cluster nodes.
+
+. Create a provisioning configuration resource file.
++
+[source,terminal]
+----
+$ touch ~/enable-provisioning-nw.yaml
+----
++
+[source,terminal]
+----
+$ vim ~/enable-provisioning-nw.yaml
+----
++
+[source,yaml]
+----
+apiVersion: metal3.io/v1alpha1
+kind: Provisioning
+metadata:
+  name: enable-provisioning-nw
+spec:
+  description: Enables a provisioning network.
+  properties:
+    provisioningNetwork: <1>
+    provisioningOSDownloadURL: <2>
+    provisioningIP: <3>
+    provisioningNetworkCIDR: <4>
+    provisioningDHCPRange: <5>
+    provisioningInterface: <6>
+    watchAllNameSpaces: <7>
+----
++
+Where:
++
+<1> The `provisioningNetwork` is one of `Managed`, `Unmanaged`, or `Disabled`. When set to `Managed`, Metal3 manages the provisioning network and the CBO will deploy the Metal3 pod with a configured DHCP server. When set to `Unmanaged`, the system administrator is responsible for configuring DHCP.
++
+<2> The `provisioningOSDownloadURL` is a valid HTTPS URL with a valid sha256 checksum that enables the Metal3 pod to download a qcow2 operating system image ending in `.qcow2.gz` or `.qcow2.xz`. This field is required whether the provisioning network is `Managed`, `Unmanaged`, or `Disabled`. For example: `http://192.168.0.1/images/rhcos-48.83.202103221318-0-openstack.x86_64.qcow2.gz?sha256=323e7ba4ba3448e340946543c963823136e1367ed0b229d2a05e1cf537642bb8`.
++
+<3> The `provisioningIP` is the static IP address that the DHCP server and ironic will be using to provision the network. This static IP address should be within the `provisioning` subnet, and outside of the DHCP range. If set, it must have a valid IP address even if the `provisioning` network is `Disabled`. The static IP address is bound to the metal3 pod. If the metal3 pod dies and moves to another server, the static IP address moves to the new server too.
++
+<4> The Classless Inter-Domain Routing (CIDR) address. If set, it must have a valid CIDR address even if the `provisioning` network is `Disabled`. For example: `192.168.0.1/24`.
++
+<5> The DHCP range. This setting is only applicable to a `Managed` provisioning network. Omit this configuration setting if the `provisioning` network is `Disabled`. For example: `192.168.0.64, 192.168.0.253`.
++
+<6> The NIC name for the `provisioning` interface on cluster nodes. This setting is only applicable to `Managed` and `Unamanged` provisioning networks. Omit this configuration setting if the `provisioning` network is `Disabled`.
++
+<7> The default value is `false`. Set this setting to `true` if you want metal3 to watch namespaces other than the default `openshift-machine-api` namespace.
+
+. Apply the Provisioning RC file to the cluster.
++
+[source,terminal]
+----
+$ oc apply -f enable-provisioning-nw.yaml
+----


### PR DESCRIPTION
This PR is a procedure for enabling the provisioning network as a day 2 operation using the Cluster Baremetal Operator.

Fixes: TELCODOCS-128

See https://issues.redhat.com/browse/TELCODOCS-128 for additional details.

Signed-off-by: John Wilkins <jowilkin@redhat.com>

/assign @iranzo 