### PR TITLE
Content for TELCODOCS-256

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
+++ b/documentation/ipi-install/modules/ipi-install-network-requirements.adoc
@@ -7,6 +7,10 @@
 
 Installer-provisioned installation of {product-title} involves several network requirements by default. First, installer-provisioned installation involves a non-routable `provisioning` network for provisioning the operating system on each bare metal node and a routable `baremetal` network. Since installer-provisioned installation deploys `ironic-dnsmasq`, the networks should have no other DHCP servers running on the same broadcast domain. Network administrators must reserve IP addresses for each node in the {product-title} cluster.
 
+ifeval::[{product-version} > 4.7]
+{product-title} 4.8 and later releases include functionality that uses cluster membership information to generate A/AAAA records, which resolve node names to their IP addresses. Once the nodes have registered with the API, the cluster can disperse node information without using CoreDNS-mDNS, thereby eliminating the network traffic associated with multicast DNS.
+endif::[]
+
 .Network Time Protocol (NTP)
 
 ifeval::[{product-version} <= 4.7]


### PR DESCRIPTION
Adds a comment about removing multicast DNS traffic in 4.8 and later releases.

Fixes: TELCODOCS-256

See https://issues.redhat.com/browse/TELCODOCS-256 for additional details.

Signed-off-by: John Wilkins <jowilkin@redhat.com>
