### PR TITLE
Section to use the disconnected registry should use heredoc

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-creating-a-disconnected-registry.adoc
+++ b/documentation/ipi-install/modules/ipi-install-creating-a-disconnected-registry.adoc
@@ -217,16 +217,18 @@ $ sed -e 's/^/  /' /opt/registry/certs/domain.crt >> install-config.yaml
 +
 [source,terminal]
 ----
-$ echo "imageContentSources:" >> install-config.yaml
-$ echo "- mirrors:" >> install-config.yaml
-$ echo "  - registry.example.com:5000/ocp4/openshift4" >> install-config.yaml
-$ echo "  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev" >> install-config.yaml
-$ echo "- mirrors:" >> install-config.yaml
-$ echo "  - registry.example.com:5000/ocp4/openshift4" >> install-config.yaml
-$ echo "  source: registry.svc.ci.openshift.org/ocp/release" >> install-config.yaml
-$ echo "- mirrors:" >> install-config.yaml
-$ echo "  - registry.example.com:5000/ocp4/openshift4" >> install-config.yaml
-$ echo "  source: quay.io/openshift-release-dev/ocp-release" >> install-config.yaml
+$ cat <<EOF >> install-config.yaml
+imageContentSources:
+- mirrors:
+  - registry.example.com:5000/ocp4/openshift4
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - registry.example.com:5000/ocp4/openshift4
+  source: registry.svc.ci.openshift.org/ocp/release
+- mirrors:
+  - registry.example.com:5000/ocp4/openshift4
+  source: quay.io/openshift-release-dev/ocp-release
+EOF
 ----
 +
 NOTE: Replace `registry.example.com` with the registry's fully qualified domain name.


### PR DESCRIPTION
Modify the install-config.yaml file to use the disconnected registry now uses
a heredoc insteadd of a bunch of echo "(...)" >> install-config.yaml

Fixes #776

Signed-off-by: Andreas Karis <akaris@redhat.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
