### PR TITLE
configurable provisioning network

### DIFF
--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -42,6 +42,10 @@ version=""
 # Empty value results in playbook failing with error message.
 build=""
 
+# Provisioning IP Network and dhcp range (default value)
+# prov_network=172.22.0.0/21
+# prov_dhcp_range="172.22.0.10,172.22.0.100"
+
 # Provisioning IP address (default value)
 prov_ip=172.22.0.3
 

--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -42,7 +42,8 @@ version=""
 # Empty value results in playbook failing with error message.
 build=""
 
-# Provisioning IP Network and dhcp range (default value)
+# (Optional) Provisioning IP Network and dhcp range (default value)
+# If defined, make sure to update 'prov_ip' with a valid IP outside of your 'prov_dhcp_range' and update all other places like 'no_proxy_list' 
 # prov_network=172.22.0.0/21
 # prov_dhcp_range="172.22.0.10,172.22.0.100"
 

--- a/ansible-ipi-install/roles/installer/templates/metal3-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/metal3-config.j2
@@ -7,7 +7,7 @@ data:
   cache_url: ''
   deploy_kernel_url: http://{{ prov_ip|ipwrap }}:6180/images/ironic-python-agent.kernel
   deploy_ramdisk_url: http://{{ prov_ip|ipwrap }}:6180/images/ironic-python-agent.initramfs
-  dhcp_range: 172.22.0.10,172.22.0.100
+  dhcp_range: {{ prov_dhcp_range | default('172.22.0.10,172.22.0.100') }}
   http_port: "6180"
   ironic_endpoint: http://{{ prov_ip|ipwrap }}:6385/v1/
   ironic_inspector_endpoint: http://{{ prov_ip|ipwrap }}:5050/v1/

--- a/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
@@ -48,6 +48,12 @@
       when:
       - not enable_virtualmedia|bool
 
+    - name: set provisioning network fact
+      set_fact:
+        prov_bridge_ip: "{{ prov_network | next_nth_usable(1) }}/{{ prov_network | ipaddr('prefix') }}"
+      when:
+        - prov_network is defined and prov_network
+
     - name: Create Bridge labeled provisioning bridge ipv4
       nmcli:
         conn_name: "{{ provisioning_bridge }}"
@@ -57,7 +63,7 @@
         ip4_method: manual
         ip6_method: disabled
         stp: off
-        ip4: 172.22.0.1/21
+        ip4: "{{ prov_bridge_ip | default('172.22.0.1/21') }}"
         state: present
       when: (not enable_virtualmedia) and
             ((ipv4_provisioning|bool) or (not ipv6_enabled|bool) or

--- a/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
+++ b/documentation/ansible-playbook/modules/ansible-playbook-modifying-the-inventoryhosts-file.adoc
@@ -54,6 +54,11 @@ version=""
 # Empty value results in playbook failing with error message.
 build=""
 
+# (Optional) Provisioning IP Network and dhcp range (default value)
+# If defined, make sure to update 'prov_ip' with a valid IP outside of your 'prov_dhcp_range' and update all other places like 'no_proxy_list' 
+# prov_network=172.22.0.0/21
+# prov_dhcp_range="172.22.0.10,172.22.0.100"
+
 # Provisioning IP address (default value)
 prov_ip=172.22.0.3
 


### PR DESCRIPTION
# Description

Provisioning bridge IP is hard coded in the script, just variable-izing it to avoid network conflicts in lab to support different networks. Now the value will  be defaulted to `172.22.0.0/21` and it can be overridden by extra vars in those cases.  

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested on a baremetal deployment

**Test Configuration**:

- Versions: OCP 4.7.11 (3 master + 2 worker)
- Hardware: Dell FC640

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
