### PR TITLE
Remove parameter 'executable' with command module

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/20_extract_installer.yml
+++ b/ansible-ipi-install/roles/installer/tasks/20_extract_installer.yml
@@ -83,7 +83,6 @@
           /usr/local/bin/oc adm release extract --registry-config {{ pullsecret_file | quote }} --command={{ cmd |quote }} --to {{ tempdir_loc }} {{ disconnected_installer | ternary(disconnected_installer, release_image) }}
   args:
     chdir: "{{ tempdir }}"
-    executable: /bin/bash
   when: (disconnected_installer|length or the_url.status == 200)
   delegate_to: "{{ disconnected_installer | ternary(groups['registry_host'][0], groups['provisioner'][0]) }}"
   tags: extract


### PR DESCRIPTION
As of Ansible 2.4, the parameter 'executable' is no longer supported

# Description

I don't know which version of Ansible is supported, but this PR remove a warning with Ansible 2.4+
Feel free to close if not appropriate.

> [WARNING]: As of Ansible 2.4, the parameter 'executable' is no longer supported with the 'command' module. Not using '/bin/bash'.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update


## Checklist

- [x] I have performed a self-review of my own code
- [x] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
