### PR TITLE
Content for TELCODOCS-250

### DIFF
--- a/documentation/ipi-install/ipi-install-expanding-the-cluster.adoc
+++ b/documentation/ipi-install/ipi-install-expanding-the-cluster.adoc
@@ -3,7 +3,6 @@
 include::modules/common-attributes.adoc[]
 :context: ipi-install-expanding
 
-
 After deploying an installer-provisioned {product-title} cluster, you can use the following procedures to expand the number of worker nodes. Ensure that each prospective worker node meets the prerequisites.
 
 [NOTE]
@@ -12,6 +11,8 @@ Expanding the cluster using RedFish Virtual Media involves meeting minimum firmw
 ====
 
 include::modules/ipi-install-preparing-the-bare-metal-node.adoc[leveloffset=+1]
+
+include::modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc[leveloffset=+1]
 
 include::modules/ipi-install-diagnosing-duplicate-mac-address.adoc[leveloffset=+2]
 

--- a/documentation/ipi-install/modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc
+++ b/documentation/ipi-install/modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc
@@ -1,0 +1,119 @@
+// This is included in the following assemblies:
+//
+// installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
+
+[id="preparing-to-deploy-with-virtual-media-on-the-baremetal-network_{context}"]
+= Preparing to deploy with Virtual Media on the baremetal network
+
+If the `provisioning` network is enabled, and you want to expand the cluster using Virtual Media on the `baremetal` network, execute the following procedure.
+
+.Procedure
+
+. Edit the provisioning configuration resource (CR) to enable deploying with Virtual Media on the `baremetal` network.
++
+[source,terminmal]
+----
+oc edit provisioning
+----
++
+[source,yaml]
+----
+  apiVersion: metal3.io/v1alpha1
+  kind: Provisioning
+  metadata:
+    creationTimestamp: "2021-08-05T18:51:50Z"
+    finalizers:
+    - provisioning.metal3.io
+    generation: 8
+    name: provisioning-configuration
+    resourceVersion: "551591"
+    uid: f76e956f-24c6-4361-aa5b-feaf72c5b526
+  spec:
+    preProvisioningOSDownloadURLs: {}
+    provisioningDHCPRange: 172.22.0.10,172.22.0.254
+    provisioningIP: 172.22.0.3
+    provisioningInterface: enp1s0
+    provisioningNetwork: Managed
+    provisioningNetworkCIDR: 172.22.0.0/24
+    provisioningOSDownloadURL: http://192.168.111.1/images/rhcos-49.84.202107010027-0-openstack.x86_64.qcow2.gz?sha256=c7dde5f96826c33c97b5a4ad34110212281916128ae11100956f400db3d5299e
+    virtualMediaViaExternalNetwork: true <1>
+  status:
+    generations:
+    - group: apps
+      hash: ""
+      lastGeneration: 7
+      name: metal3
+      namespace: openshift-machine-api
+      resource: deployments
+    - group: apps
+      hash: ""
+      lastGeneration: 1
+      name: metal3-image-cache
+      namespace: openshift-machine-api
+      resource: daemonsets
+    observedGeneration: 8
+    readyReplicas: 0
+----
++
+<1> Add `virtualMediaViaExternalNetwork: true` to the provisioning CR.
+
+
+. Edit the machine set to use the API VIP address.
++
+[source,terminal]
+----
+oc edit machineset
+----
++
+[source,yaml]
+----
+  apiVersion: machine.openshift.io/v1beta1
+  kind: MachineSet
+  metadata:
+    creationTimestamp: "2021-08-05T18:51:52Z"
+    generation: 11
+    labels:
+      machine.openshift.io/cluster-api-cluster: ostest-hwmdt
+      machine.openshift.io/cluster-api-machine-role: worker
+      machine.openshift.io/cluster-api-machine-type: worker
+    name: ostest-hwmdt-worker-0
+    namespace: openshift-machine-api
+    resourceVersion: "551513"
+    uid: fad1c6e0-b9da-4d4a-8d73-286f78788931
+  spec:
+    replicas: 2
+    selector:
+      matchLabels:
+        machine.openshift.io/cluster-api-cluster: ostest-hwmdt
+        machine.openshift.io/cluster-api-machineset: ostest-hwmdt-worker-0
+    template:
+      metadata:
+        labels:
+          machine.openshift.io/cluster-api-cluster: ostest-hwmdt
+          machine.openshift.io/cluster-api-machine-role: worker
+          machine.openshift.io/cluster-api-machine-type: worker
+          machine.openshift.io/cluster-api-machineset: ostest-hwmdt-worker-0
+      spec:
+        metadata: {}
+        providerSpec:
+          value:
+            apiVersion: baremetal.cluster.k8s.io/v1alpha1
+            hostSelector: {}
+            image:
+              checksum: http:/172.22.0.3:6181/images/rhcos-49.84.202107010027-0-openstack.x86_64.qcow2/cached-rhcos-49.84.202107010027-0-openstack.x86_64.qcow2.md5sum <1>
+              url: http://172.22.0.3:6181/images/rhcos-49.84.202107010027-0-openstack.x86_64.qcow2/cached-rhcos-49.84.202107010027-0-openstack.x86_64.qcow2 <2>
+            kind: BareMetalMachineProviderSpec
+            metadata:
+              creationTimestamp: null
+            userData:
+              name: worker-user-data
+  status:
+    availableReplicas: 2
+    fullyLabeledReplicas: 2
+    observedGeneration: 11
+    readyReplicas: 2
+    replicas: 2
+----
++
+<1> Edit the `checksum` URL to use the API VIP address.
+<2> Edit the `url` URL to use the API VIP address.


### PR DESCRIPTION
Adds a procedure for expaning the cluster using Virtual Media on the baremetal network.

Fixes: TELCODOCS-250

See https://issues.redhat.com/browse/TELCODOCS-250 for additional details.

Signed-off-by: John Wilkins <jowilkin@redhat.com>
