### PR TITLE
[WIP] Fixed bootstrap images cleanup in default_libvirt_pool_dir

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/59_cleanup_bootstrap.yml
+++ b/ansible-ipi-install/roles/installer/tasks/59_cleanup_bootstrap.yml
@@ -46,7 +46,7 @@
   find:
     paths: "{{ item }}"
     patterns: '*-bootstrap,*-bootstrap.ign'
-    file_type: directory
+    file_type: any
   register: find_results
   with_items: "{{ default_libvirt_pool_dir }}"
   become: yes


### PR DESCRIPTION
# Description

Fixes #799  (issue): Bootstrap images in default_libvirt_pool_dir are never deleted because they're files and not directories.

Before fix: only directories `patterns: '*-bootstrap,*-bootstrap.ign'` are deleted at cleanup. Files remain untouched, _i.e._ cleanup doesn't work. 

With fix: both directories and files `patterns: '*-bootstrap,*-bootstrap.ign'` are deleted.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing

### Tests in local

Here is my testing structure, `-iamdir-` are directories and `-iamfile-` are files.

```
$ tree
.
├── bootstrap_cleanup.yml
└── images
    ├── cluster5-iamdir-bootstrap
    │   ├── image1
    │   └── image2
    ├── cluster5-iamfile-bootstrap
    └── cluster5-iamfile-bootstrap.ign
```

I use [this part of code](https://github.com/openshift-kni/baremetal-deploy/blob/master/ansible-ipi-install/roles/installer/tasks/59_cleanup_bootstrap.yml#L45-L66) to test on my laptop. The only significant change is `directory` -> `any`.

```
---
- hosts: local
  vars: 
    default_libvirt_pool_dir:
      - ./images
  tasks:
    - name: Find old bootstrap VM Storage
      find:
        paths: "{{ item }}"
        patterns: '*-bootstrap,*-bootstrap.ign'
        file_type: any
      register: find_results
      with_items: "{{ default_libvirt_pool_dir }}"
      tags: cleanup

    - name: Create list of old paths
      set_fact:
        vm_paths: "{{ vm_paths  | default([]) + find_results.results[item|int] | json_query('files[*].path') }}"
      with_sequence: start=0 count={{ default_libvirt_pool_dir | length }}

    - name: Delete old bootstrap VMs Storage
      file:
        path: "{{ item }}"
        state: absent
      loop: "{{ vm_paths }}"
      tags: cleanup
```

Here are the execution results

```
$ ansible-playbook -i inventory bootstrap_cleanup.yml 

PLAY [local] *******************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************
ok: [127.0.0.1]

TASK [Find old bootstrap VM Storage] *******************************************************************************************
ok: [127.0.0.1] => (item=./images)

TASK [Create list of old paths] ************************************************************************************************
ok: [127.0.0.1] => (item=0)

TASK [Delete old bootstrap VMs Storage] ****************************************************************************************
changed: [127.0.0.1] => (item=images/cluster5-iamfile-bootstrap)
changed: [127.0.0.1] => (item=images/cluster5-iamfile-bootstrap.ign)
changed: [127.0.0.1] => (item=images/cluster5-iamdir-bootstrap)

PLAY RECAP *********************************************************************************************************************
127.0.0.1                  : ok=4    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0  
```

Both files and directories were deleted, cleanup worked fine.

```
$ tree
.
├── bootstrap_cleanup.yml
└── images
```

### [TODO] Tests on cluster 

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [X] I have performed a self-review of my own code
- [X] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
