### PR TITLE
updated version template

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/40_create_manifest.yml
+++ b/ansible-ipi-install/roles/installer/tasks/40_create_manifest.yml
@@ -25,5 +25,5 @@
     group: "{{ ansible_user }}"
     mode: '0644'
     remote_src: yes
-  when: (release_version[0]|int == 4) and (release_version[2]|int <= 3)
+  when: (release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int <= 3)
   tags: manifests

--- a/ansible-ipi-install/roles/installer/tasks/50_extramanifests.yml
+++ b/ansible-ipi-install/roles/installer/tasks/50_extramanifests.yml
@@ -11,7 +11,7 @@
   when:
     - ipv6_enabled|bool
     - dualstack_baremetal
-    - release_version[0]|int == 4 and release_version[2]|int < 8
+    - release_version.split('.')[0]|int == 4 and release_version.split('.')[1]|int < 8
   delegate_to: localhost
 
 - name: Add Manifests from files dir

--- a/ansible-ipi-install/roles/installer/tasks/main.yml
+++ b/ansible-ipi-install/roles/installer/tasks/main.yml
@@ -25,7 +25,7 @@
   - pullsecret
   - extract
 - include_tasks: 23_rhcos_image_paths.yml
-  when: ((release_version[0]|int == 4) and (release_version[2]|int <= 3)) or cache_enabled|bool
+  when: ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int <= 3)) or cache_enabled|bool
   tags: rhcospath
 - include_tasks: 24_rhcos_image_cache.yml
   when: cache_enabled|bool
@@ -35,7 +35,7 @@
 - include_tasks: 25_create-install-config.yml
   tags: installconfig
 - include_tasks: 30_create_metal3.yml
-  when: (release_version[0]|int == 4) and (release_version[2]|int <= 3)
+  when: (release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int <= 3)
   tags: metal3config
 - include_tasks: 40_create_manifest.yml
   tags: manifests

--- a/ansible-ipi-install/roles/installer/templates/etc-chrony.conf.j2
+++ b/ansible-ipi-install/roles/installer/templates/etc-chrony.conf.j2
@@ -11,10 +11,10 @@ spec:
       security:
         tls: {}
       timeouts: {}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int > 5)) %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int > 5)) %}
       version: 3.1.0
 {% endif %}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int < 6)) %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 6)) %}
       version: 2.2.0
 {% endif %}
     networkd: {}
@@ -23,20 +23,20 @@ spec:
       files:
       - contents:
           source: data:text/plain;charset=utf-8;base64,{{ chronyconfig }}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int < 6)) %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 6)) %}
           verification: {}
         filesystem: root
 {% endif %}
         group:
           name: root
         mode: 420
-{% if ((release_version[0]|int == 4) and (release_version[2]|int > 5)) %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int > 5)) %}
         overwrite: true
 {% endif %}
         path: /etc/chrony.conf
         user:
           name: root
-{% if ((release_version[0]|int == 4) and (release_version[2]|int < 6)) %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 6)) %}
     systemd: {}
 {% endif %}
   osImageURL: ""

--- a/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
@@ -45,7 +45,7 @@ platform:
   baremetal:
     apiVIP: {{ apivip }}
     ingressVIP: {{ ingressvip }}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int < 5)) %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 5)) %}
     dnsVIP: {{ dnsvip }}
 {% endif %}
 {% if baremetal_bridge != 'baremetal' %}
@@ -65,10 +65,10 @@ platform:
       - name: {{ hostvars[host]['inventory_hostname'] }}
         role: {{ hostvars[host]['role'] }}
         bmc:
-{% if groups['dell_hosts_redfish'] is defined and host in groups['dell_hosts_redfish'] and ((release_version[0]|int > 4) or ((release_version[0]|int == 4) and (release_version[2]|int >= 6))) and enable_virtualmedia|bool %}
+{% if groups['dell_hosts_redfish'] is defined and host in groups['dell_hosts_redfish'] and ((release_version.split('.')[0]|int > 4) or ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 6))) and enable_virtualmedia|bool %}
           address: idrac-virtualmedia://{{ hostvars[host]['ipmi_address']|ipwrap }}/redfish/v1/Systems/System.Embedded.1
           disableCertificateVerification: {{ disable_bmc_certificate_verification }}
-{% elif groups['hp_hosts_redfish'] is defined and host in groups['hp_hosts_redfish'] and ((release_version[0]|int > 4) or ((release_version[0]|int == 4) and (release_version[2]|int >= 6))) and enable_virtualmedia|bool %}
+{% elif groups['hp_hosts_redfish'] is defined and host in groups['hp_hosts_redfish'] and ((release_version.split('.')[0]|int > 4) or ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 6))) and enable_virtualmedia|bool %}
           address: redfish-virtualmedia://{{ hostvars[host]['ipmi_address']|ipwrap }}/redfish/v1/Systems/1
           disableCertificateVerification: {{ disable_bmc_certificate_verification }}
 {% elif ansible_system_vendor == 'Dell Inc.' %}
@@ -81,14 +81,14 @@ platform:
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}
         bootMACAddress: {{ hostvars[host]['provision_mac'] }}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int < 6)) %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 6)) %}
 {% if 'hardware_profile' in hostvars[host] %}
         hardwareProfile: {{ hostvars[host]['hardware_profile'] }}
 {% else %}
         hardwareProfile: default
 {% endif %}
 {% endif %}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int >= 6)) %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 6)) %}
 {% if bootmode is defined and bootmode == 'legacy' %}
         bootMode: legacy
 {% endif %}
@@ -103,10 +103,10 @@ platform:
       - name: {{ hostvars[host]['inventory_hostname'] }}
         role: {{ hostvars[host]['role'] }}
         bmc:
-{% if groups['dell_hosts_redfish'] is defined and host in groups['dell_hosts_redfish'] and ((release_version[0]|int > 4) or ((release_version[0]|int == 4) and (release_version[2]|int >= 6))) and enable_virtualmedia|bool %}
+{% if groups['dell_hosts_redfish'] is defined and host in groups['dell_hosts_redfish'] and ((release_version.split('.')[0]|int > 4) or ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 6))) and enable_virtualmedia|bool %}
           address: idrac-virtualmedia://{{ hostvars[host]['ipmi_address']|ipwrap }}/redfish/v1/Systems/System.Embedded.1
           disableCertificateVerification: {{ disable_bmc_certificate_verification }}
-{% elif groups['hp_hosts_redfish'] is defined and host in groups['hp_hosts_redfish'] and ((release_version[0]|int > 4) or ((release_version[0]|int == 4) and (release_version[2]|int >= 6))) and enable_virtualmedia|bool %}
+{% elif groups['hp_hosts_redfish'] is defined and host in groups['hp_hosts_redfish'] and ((release_version.split('.')[0]|int > 4) or ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 6))) and enable_virtualmedia|bool %}
           address: redfish-virtualmedia://{{ hostvars[host]['ipmi_address']|ipwrap }}/redfish/v1/Systems/1
           disableCertificateVerification: {{ disable_bmc_certificate_verification }}
 {% elif ansible_system_vendor == 'Dell Inc.' %}
@@ -119,14 +119,14 @@ platform:
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}
         bootMACAddress: {{ hostvars[host]['provision_mac'] }}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int < 6)) %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 6)) %}
 {% if 'hardware_profile' in hostvars[host] %}
         hardwareProfile: {{ hostvars[host]['hardware_profile'] }}
 {% else %}
         hardwareProfile: unknown
 {% endif %}
 {% endif %}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int >= 6)) %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 6)) %}
 {% if bootmode is defined and bootmode == 'legacy' %}
         bootMode: legacy
 {% endif %}

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -45,14 +45,14 @@ platform:
   baremetal:
     apiVIP: {{ apivip }}
     ingressVIP: {{ ingressvip }}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int < 5)) %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 5)) %}
     dnsVIP: {{ dnsvip }}
 {% endif %}
     provisioningBridge: {{ provisioning_bridge }}
 {% if baremetal_bridge != 'baremetal' %}
     externalBridge: {{ baremetal_bridge }}
 {% endif %}
-{% if (release_version[0]|int > 4) or ((release_version[0]|int == 4) and (release_version[2]|int > 3)) %}
+{% if (release_version.split('.')[0]|int > 4) or ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int > 3)) %}
     provisioningNetworkInterface: {{ masters_prov_nic }}
     provisioningNetworkCIDR: {{ provisioning_subnet }}
 {% endif %}
@@ -67,10 +67,10 @@ platform:
       - name: {{ hostvars[host]['inventory_hostname'] }}
         role: {{ hostvars[host]['role'] }}
         bmc:
-{% if groups['dell_hosts_redfish'] is defined and host in groups['dell_hosts_redfish'] and ((release_version[0]|int > 4) or ((release_version[0]|int == 4) and (release_version[2]|int >= 5))) %}
+{% if groups['dell_hosts_redfish'] is defined and host in groups['dell_hosts_redfish'] and ((release_version.split('.')[0]|int > 4) or ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 5))) %}
           address: redfish://{{ hostvars[host]['ipmi_address']|ipwrap }}/redfish/v1/Systems/System.Embedded.1
           disableCertificateVerification: {{ disable_bmc_certificate_verification }}
-{% elif groups['hp_hosts_redfish'] is defined and host in groups['hp_hosts_redfish'] and ((release_version[0]|int > 4) or ((release_version[0]|int == 4) and (release_version[2]|int >= 5))) %}
+{% elif groups['hp_hosts_redfish'] is defined and host in groups['hp_hosts_redfish'] and ((release_version.split('.')[0]|int > 4) or ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 5))) %}
           address: redfish://{{ hostvars[host]['ipmi_address']|ipwrap }}/redfish/v1/Systems/1
           disableCertificateVerification: {{ disable_bmc_certificate_verification }}
 {% else %}
@@ -79,14 +79,14 @@ platform:
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}
         bootMACAddress: {{ hostvars[host]['provision_mac'] }}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int < 6)) %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 6)) %}
 {% if 'hardware_profile' in hostvars[host] %}
         hardwareProfile: {{ hostvars[host]['hardware_profile'] }}
 {% else %}
         hardwareProfile: default
 {% endif %}
 {% endif %}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int >= 6)) %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 6)) %}
 {% if bootmode is defined and bootmode == 'legacy' %}
         bootMode: legacy
 {% endif %}
@@ -113,14 +113,14 @@ platform:
           username: {{ hostvars[host]['ipmi_user'] }}
           password: {{ hostvars[host]['ipmi_password'] }}
         bootMACAddress: {{ hostvars[host]['provision_mac'] }}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int < 6)) %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 6)) %}
 {% if 'hardware_profile' in hostvars[host] %}
         hardwareProfile: {{ hostvars[host]['hardware_profile'] }}
 {% else %}
         hardwareProfile: unknown
 {% endif %}
 {% endif %}
-{% if ((release_version[0]|int == 4) and (release_version[2]|int >= 6)) %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 6)) %}
 {% if bootmode is defined and bootmode == 'legacy' %}
         bootMode: legacy
 {% endif %}

--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -285,7 +285,7 @@
 - name: Fail if dual-stack is requested and build does not support it
   fail:
     msg: This release {{ release_version }} does not support dual-stack deployments
-  when: release_version[0]|int == 4 and release_version[2]|int < 6 and dualstack_baremetal
+  when: release_version.split('.')[0]|int == 4 and release_version.split('.')[1]|int < 6 and dualstack_baremetal
   tags:
   - always
   - validation
@@ -378,7 +378,7 @@
   fail:
     msg: "dnsvip variable is undefined or empty."
   when:
-  - ((release_version[0]|int == 4) and (release_version[2]|int < 5))
+  - ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 5))
   - ((dnsvip is undefined) or (dnsvip|length == 0))
   tags:
   - always

--- a/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
@@ -67,7 +67,7 @@
         state: present
       when: (not enable_virtualmedia) and
             ((ipv4_provisioning|bool) or (not ipv6_enabled|bool) or
-            ((release_version[0]|int == 4) and (release_version[2]|int == 3)))
+            ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int == 3)))
 
     - name: Create Bridge slave on provisioning nic ipv4
       nmcli:
@@ -80,7 +80,7 @@
         state: present
       when: (not enable_virtualmedia) and
             ((ipv4_provisioning|bool) or (not ipv6_enabled|bool) or
-            ((release_version[0]|int == 4) and (release_version[2]|int == 3)))
+            ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int == 3)))
 
     - name: Create Bridge labeled provisioning bridge ipv6
       nmcli:
@@ -96,8 +96,8 @@
       when:
         - not enable_virtualmedia|bool
         - ipv6_enabled|bool
-        - release_version[0]|int == 4 and release_version[2]|int > 3 or
-          release_version[0]|int > 4
+        - release_version.split('.')[0]|int == 4 and release_version.split('.')[1]|int > 3 or
+          release_version.split('.')[0]|int > 4
         - not ipv4_provisioning|bool
 
     - name: Create Bridge slave on provisioning nic ipv6
@@ -112,8 +112,8 @@
       when:
         - not enable_virtualmedia|bool
         - ipv6_enabled|bool
-        - release_version[0]|int == 4 and release_version[2]|int > 3 or
-          release_version[0]|int > 4
+        - release_version.split('.')[0]|int == 4 and release_version.split('.')[1]|int > 3 or
+          release_version.split('.')[0]|int > 4
         - not ipv4_provisioning|bool
 
     - name: Create Bridge labeled {{ baremetal_bridge }} for ipv4

--- a/ansible-ipi-install/roles/node-prep/tasks/45_networking_facts.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/45_networking_facts.yml
@@ -37,7 +37,7 @@
     ip: "{{ ansible_facts[provisioning_bridge]['ipv4']['address'] }}/{{ ansible_facts[provisioning_bridge]['ipv4']['netmask'] }}"
   when: (not enable_virtualmedia) and
         ((ipv4_provisioning|bool) or (not ipv6_enabled|bool) or
-        ((release_version[0]|int == 4) and (release_version[2]|int == 3)))
+        ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int == 3)))
   tags:
   - network_facts
 
@@ -50,8 +50,8 @@
     - not enable_virtualmedia|bool
     - ipv6_enabled|bool
     - not ipv4_provisioning|bool
-    - release_version[0]|int == 4 and release_version[2]|int > 3 or
-      release_version[0]|int > 4
+    - release_version.split('.')[0]|int == 4 and release_version.split('.')[1]|int > 3 or
+      release_version.split('.')[0]|int > 4
   tags:
   - network_facts
 


### PR DESCRIPTION
# Description

Template is missing to parse second decimal of openshift `version` for releases >= 4.10, so many conditional tasks could break.

currently `release_version[2]|int` gives `1` for 4.10, which is not right.
updated to `release_version.split('.')[1]|int` results `10`

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
