### PR TITLE
Add defaults for async deployment timeouts

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/60_deploy_ocp.yml
+++ b/ansible-ipi-install/roles/installer/tasks/60_deploy_ocp.yml
@@ -40,7 +40,7 @@
         /usr/local/bin/openshift-baremetal-install --dir {{ dir }} --log-level debug wait-for bootstrap-complete
       register: wait_for_bootstrap_result
       until: wait_for_bootstrap_result is succeeded
-      retries: "{{ increase_bootstrap_timeout|int }}"
+      retries: "{{ increase_bootstrap_timeout|default(1)|int }}"
       delay: 1
 
     - name: Wait for Install Complete
@@ -48,7 +48,7 @@
         /usr/local/bin/openshift-baremetal-install --dir {{ dir }} --log-level debug wait-for install-complete
       register: wait_for_install_result
       until: wait_for_install_result is succeeded
-      retries: "{{ increase_install_timeout|int }}"
+      retries: "{{ increase_install_timeout|default(1)|int }}"
       delay: 1
   when: increase_bootstrap_timeout is defined or increase_install_timeout is defined
   tags: install


### PR DESCRIPTION
# Description

For users wanting to provision a bare metal cluster two optional vars `increase_bootstrap_timeout` and `increase_install_timeout` for allowing retries during the bootstrap and install processes. When only one of those variables is defined, the other task will fail when an undefined variable is referenced.

This adds a sane default of `1` to account for cases where only one of those timeout variables is defined.

Fixes #808

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Provision a baremetal cluster with `increase_bootstrap_timeout` set and `increase_install_timeout` undefined

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
