### PR TITLE
Update install-config.j2 template to support provisioningDHCPRange

### DIFF
--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -55,6 +55,9 @@ platform:
 {% if (release_version.split('.')[0]|int > 4) or ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int > 3)) %}
     provisioningNetworkInterface: {{ masters_prov_nic }}
     provisioningNetworkCIDR: {{ provisioning_subnet }}
+{% if prov_dhcp_range is defined and prov_dhcp_range|length %}
+    provisioningDHCPRange: {{ prov_dhcp_range }}
+{% endif %}    
 {% endif %}
 {% if bootstraposimage is defined and bootstraposimage|length %}
     bootstrapOSImage: {{ bootstraposimage }}


### PR DESCRIPTION
# Description

Allow to set the provisioningDHCPRange if the prov_dhcp_range variable is set.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Using the DCI Openshift Agent, which clone this repo for each run.
(I overwrite the repo url to my fork to test it)

