### PR TITLE
Use rhcos json stream on 4.8+

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/23_rhcos_image_paths.yml
+++ b/ansible-ipi-install/roles/installer/tasks/23_rhcos_image_paths.yml
@@ -1,29 +1,59 @@
 ---
-- name: Get COMMIT_ID
-  shell: |
-    /usr/local/bin/openshift-baremetal-install version | grep '^built from commit' | awk '{print $4}'
-  register: commit_id
-  tags: rhcospath
+- name: RHCOS image path (pre 4.8)
+  block:
+    - name: Get COMMIT_ID
+      shell: |
+        /usr/local/bin/openshift-baremetal-install version | grep '^built from commit' | awk '{print $4}'
+      register: commit_id
+      tags: rhcospath
 
-- name: Get the URLs
-  set_fact:
-    offline_url: "{{ webserver_url }}/{{ version }}/rhcos.json"
-    online_url: "https://raw.githubusercontent.com/openshift/installer/{{ commit_id.stdout }}/data/data/rhcos.json"
+    - name: Get the URLs
+      set_fact:
+        offline_url: "{{ webserver_url }}/{{ version }}/rhcos.json"
+        online_url: "https://raw.githubusercontent.com/openshift/installer/{{ commit_id.stdout }}/data/data/rhcos.json"
 
-- name: Get RHCOS JSON File
-  uri:
-    url: "{{ (disconnected_installer|length == 0 and the_url.status == -1) | ternary(offline_url, online_url) }}"
-    return_content: yes
-  until: rhcos_json.status == 200
-  retries: 6 # 1 minute (10 * 6)
-  delay: 10 # Every 10 seconds
-  register: rhcos_json
-  delegate_to: "{{ disconnected_installer | ternary(groups['registry_host'][0], groups['provisioner'][0]) }}"
-  tags: rhcospath
+    - name: Get RHCOS JSON File
+      uri:
+        url: "{{ (disconnected_installer|length == 0 and the_url.status == -1) | ternary(offline_url, online_url) }}"
+        return_content: yes
+      until: rhcos_json.status == 200
+      retries: 6 # 1 minute (10 * 6)
+      delay: 10 # Every 10 seconds
+      register: rhcos_json
+      delegate_to: "{{ disconnected_installer | ternary(groups['registry_host'][0], groups['provisioner'][0]) }}"
+      tags: rhcospath
 
-- name: Set Facts for RHCOS_URI and RHCOS_PATH
-  set_fact:
-    rhcos_qemu_uri: "{{ rhcos_json.json | json_query('images.qemu.path') }}"
-    rhcos_uri: "{{ rhcos_json.json | json_query('images.openstack.path') }}"
-    rhcos_path: "{{ rhcos_json.json | json_query('baseURI') }}"
-  tags: rhcospath
+    - name: Set Facts for RHCOS_URI and RHCOS_PATH
+      set_fact:
+        rhcos_qemu_uri: "{{ rhcos_json.json | json_query('images.qemu.path') }}"
+        rhcos_uri: "{{ rhcos_json.json | json_query('images.openstack.path') }}"
+        rhcos_path: "{{ rhcos_json.json | json_query('baseURI') }}"
+      tags: rhcospath
+  when: (release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int <= 7)
+
+- name: RHCOS image path (4.8+)
+  block:
+    - name: Extract rhcos.json
+      shell: |
+        /usr/local/bin/openshift-baremetal-install coreos print-stream-json
+      register: rhcos_json_stream
+      retries: 3
+      delay: 10
+      until: rhcos_json_stream is not failed
+      tags: rhcospath
+
+    - name: Set rhcos_json fact
+      set_fact:
+        rhcos_json: "{{ rhcos_json_stream.stdout | from_json }}"
+      tags: rhcospath
+
+    - name: Set Facts for RHCOS_URI and RHCOS_PATH
+      set_fact:
+        rhcos_qemu_uri: "{{ rhcos_json | json_query(rhcos_qemu_key) | basename }}"
+        rhcos_path: "{{ rhcos_json | json_query(rhcos_qemu_key) | dirname + '/' }}"
+        rhcos_uri: "{{ rhcos_json | json_query(rhcos_openstack_key) | basename }}"
+      vars:
+        rhcos_qemu_key: 'architectures.x86_64.artifacts.qemu.formats."qcow2.gz".disk.location'
+        rhcos_openstack_key: 'architectures.x86_64.artifacts.openstack.formats."qcow2.gz".disk.location'
+      tags: rhcospath
+  when: (release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 8)

--- a/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
+++ b/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
@@ -83,12 +83,25 @@
   tags: cache
 
 # rhcos_json fact already set in 23_rhcos_image_paths.yaml
-- name: Set facts for RHCOS_QEMU_SHA256 and RHCOS_SHA256
+- name: Set facts for RHCOS_QEMU_SHA256 and RHCOS_SHA256 (pre 4.8)
   set_fact:
     rhcos_qemu_sha256: "{{ rhcos_json.json | json_query('images.qemu.sha256') }}"
     rhcos_qemu_sha256_unzipped: '{{ rhcos_json.json | json_query(''images.qemu."uncompressed-sha256"'') }}'
     rhcos_sha256: "{{ rhcos_json.json | json_query('images.openstack.sha256') }}"
   tags: cache
+  when: ((release_version.split('.')[0] | int) < 4) and (release_version.split('.')[1] | int) <= 7)))
+
+- name: Set facts for RHCOS_QEMU_SHA256 and RHCOS_SHA256 (4.8+)
+  set_fact:
+    rhcos_qemu_sha256: "{{ rhcos_json | json_query(rhcos_qemu_key) }}"
+    rhcos_qemu_sha256_unzipped: "{{ rhcos_json | json_query(rhcos_qemu_sha_unzip_key) }}"
+    rhcos_sha256: "{{ rhcos_json | json_query(rhcos_openstack_sha_key) }}"
+  vars:
+    rhcos_qemu_sha_key: 'architectures.x86_64.artifacts.qemu.formats."qcow2.gz".disk.sha256'
+    rhcos_qemu_sha_unzip_key: 'architectures.x86_64.artifacts.qemu.formats."qcow2.gz".disk."uncompressed-sha256"'
+    rhcos_openstack_sha_key: 'architectures.x86_64.artifacts.openstack.formats."qcow2.gz".disk.sha256'
+  tags: cache
+  when: ((release_version.split('.')[0] | int) < 4) and (release_version.split('.')[1] | int) >= 8)))
 
 - name: Download {{ rhcos_qemu_uri }} for cache
   get_url:

--- a/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
+++ b/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
@@ -93,7 +93,7 @@
 
 - name: Set facts for RHCOS_QEMU_SHA256 and RHCOS_SHA256 (4.8+)
   set_fact:
-    rhcos_qemu_sha256: "{{ rhcos_json | json_query(rhcos_qemu_key) }}"
+    rhcos_qemu_sha256: "{{ rhcos_json | json_query(rhcos_qemu_sha_key) }}"
     rhcos_qemu_sha256_unzipped: "{{ rhcos_json | json_query(rhcos_qemu_sha_unzip_key) }}"
     rhcos_sha256: "{{ rhcos_json | json_query(rhcos_openstack_sha_key) }}"
   vars:

--- a/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
+++ b/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
@@ -89,7 +89,7 @@
     rhcos_qemu_sha256_unzipped: '{{ rhcos_json.json | json_query(''images.qemu."uncompressed-sha256"'') }}'
     rhcos_sha256: "{{ rhcos_json.json | json_query('images.openstack.sha256') }}"
   tags: cache
-  when: ((release_version.split('.')[0] | int) < 4) and (release_version.split('.')[1] | int) <= 7)))
+  when: (release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int <= 7)
 
 - name: Set facts for RHCOS_QEMU_SHA256 and RHCOS_SHA256 (4.8+)
   set_fact:
@@ -101,7 +101,7 @@
     rhcos_qemu_sha_unzip_key: 'architectures.x86_64.artifacts.qemu.formats."qcow2.gz".disk."uncompressed-sha256"'
     rhcos_openstack_sha_key: 'architectures.x86_64.artifacts.openstack.formats."qcow2.gz".disk.sha256'
   tags: cache
-  when: ((release_version.split('.')[0] | int) < 4) and (release_version.split('.')[1] | int) >= 8)))
+  when: (release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 8)
 
 - name: Download {{ rhcos_qemu_uri }} for cache
   get_url:


### PR DESCRIPTION
# Description

Use rhcos json stream on 4.8+

- Use openshift-baremetal-install functionality to obtain RHCOS image paths on 4.8+
- Starting in 4.8 the installer contains pinned images of RHCOS in the binary
- Format of the metadata stream is different, parsing differs to older versions

References:
- https://github.com/openshift/enhancements/blob/master/enhancements/coreos-bootimages.md
- https://github.com/openshift/installer/blob/master/docs/user/overview.md#coreos-bootimages

Fixes #830 

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested in Libvirt through dci: https://www.distributed-ci.io/jobs/f338780b-24a9-48ac-b115-f8cde2310922/jobStates 

Note: The job is using 4.10 nightly with 4.10.0 2022-01-17 as newer nightly builds have been failing to complete the install. 4.9 is still being validated and will provide the job once finished or it can be tested through this PR.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
