### PR TITLE
Add Optional support for FIPS enabled clusters

### DIFF
--- a/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
@@ -33,6 +33,9 @@ networking:
   - 172.30.0.0/16
   - fd03::/112
 {% endif %}
+{% if fips_enabled is defined and fips_enabled|bool %}
+fips: true
+{% endif %}
 compute:
 - name: worker
   replicas: {{ numworkers }}

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -33,6 +33,9 @@ networking:
   - 172.30.0.0/16
   - fd03::/112
 {% endif %}
+{% if fips_enabled is defined and fips_enabled|bool %}
+fips: true
+{% endif %}
 compute:
 - name: worker
   replicas: {{ numworkers }}


### PR DESCRIPTION
This change adds a new ansible optional variable `fips_enabled` allowing to deploy FIPS enabled clusters (https://www.nist.gov/itl/fips-general-information) when set to `true`.
