### PR TITLE
BZ-1937458: Remove reference to openstack baremetal and update it to baremetal

### DIFF
--- a/documentation/ipi-install/modules/ipi-install-troubleshooting-ironic-bootstrap.adoc
+++ b/documentation/ipi-install/modules/ipi-install-troubleshooting-ironic-bootstrap.adoc
@@ -94,7 +94,7 @@ Make sure in the file above you change <bootstrapProvisioningIp> with the value 
 +
 [source,terminal]
 ----
-[root@1facad6bccff /]# openstack baremetal node list
+[root@1facad6bccff /]# baremetal node list
 ----
 +
 


### PR DESCRIPTION
# Description
Updates instance of `openstack baremetal` and update it to `baremetal` to address BZ-1937458. 
(Updates `ipi-install-troubleshooting-ironic-bootstrap.adoc` module that is included in the `ipi-install-upstream-troubleshooting.adoc` assembly)

Fixes # (issue)
https://bugzilla.redhat.com/show_bug.cgi?id=1937458

## Updates upstream documentation
Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
