### PR TITLE
Add support to pass NMstate vars in install-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ It also contains optional features focused on low-latency workloads, NFV workloa
 - [Performance](features/performance/). Performance-related features like Hugepages, real-time kernel, CPU Manager and Topology Manager.
 - [Bonding](features/bonding/). A helper script to create bonding devices with ignition and/or NMstate.
 - [DPDK](features/dpdk/). Example workload that uses DPDK libraries for packet processing.
-- [Kubernetes NMstate](features/kubernetes-nmstate/). Node-networking configuration driven by Kubernetes and executed
-  by NMstate.
+- [Kubernetes NMstate](features/kubernetes-nmstate/). Node-networking configuration driven by Kubernetes and executed by NMstate.
+- [Kubernetes NMstate day1](features/kubernetes-nmstate/day1/). Node-networking configuration driven by Kubernetes and executed by NMstate during the deployment of a cluster, by adding settings to install-config.yaml
 - [PTP](features/ptp). This operator manages cluster-wide Precision Time Protocol (PTP) configuration.
 - [SCTP](features/sctp). These assets enable Stream Control Transmission Protocol (SCTP) in the RHCOS
   worker nodes.

--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -169,7 +169,7 @@ pullsecret=""
 # (Optional) Change the boot mode of the OpenShift cluster nodes to legacy mode (BIOS). Default is UEFI.
 #bootmode=legacy
 
-# Master nodes
+# Master/Worker nodes
 # The hardware_profile is used by the baremetal operator to match the hardware discovered on the host
 # See https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md#baremetalhost-status
 # ipmi_port is optional for each host. 623 is the common default used if omitted
@@ -181,6 +181,11 @@ pullsecret=""
 # Root Device Hint values are case sensitive. If incorrect case given, entry omitted from install-config.yaml
 # root_device_hint="deviceName"
 # root_device_hint_value="/dev/sda"
+ 
+# (Optional) Modify the path to set custom networking configuration with NMState to the deployed nodes
+# The following variable allows to pass the networkConfig settings from YAML files in NMstate format:
+# master_network_config_file="/path/to/your/master_nmstate_file.yaml"
+# worker_network_config_file="/path/to/your/worker_nmstate_file.yaml"
 
 [masters]
 master-0 name=master-0 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.1 ipmi_port=623 provision_mac=ec:f4:bb:da:0c:58 hardware_profile=default poweroff=true

--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -183,9 +183,10 @@ pullsecret=""
 # root_device_hint_value="/dev/sda"
  
 # (Optional) Modify the path to set custom networking configuration with NMState to the deployed nodes
-# The following variable allows to pass the networkConfig settings from YAML files in NMstate format:
-# master_network_config_file="/path/to/your/master_nmstate_file.yaml"
-# worker_network_config_file="/path/to/your/worker_nmstate_file.yaml"
+# The following variable allows to pass the networkConfig settings from YAML files in NMstate format
+# The files can include jinja format and render defined variables from master/worker nodes
+# master_network_config_template="/path/to/your/master_nmstate_file.yaml"
+# worker_network_config_template="/path/to/your/worker_nmstate_file.yaml"
 
 [masters]
 master-0 name=master-0 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.1 ipmi_port=623 provision_mac=ec:f4:bb:da:0c:58 hardware_profile=default poweroff=true

--- a/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
@@ -100,6 +100,12 @@ platform:
           {{ hostvars[host]['root_device_hint'] }}: {{ hostvars[host]['root_device_hint_value'] }}
 {% endif %}
 {% endif %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) %}
+{% if rendered_master_nmstate_yml is defined and rendered_master_nmstate_yml|length %}
+        networkConfig:
+{{ rendered_master_nmstate_yml | indent(10, true) }}
+{% endif %}
+{% endif %}
 {% endfor %}
 {% if groups['workers'] is defined %}
 {% for host in groups['workers'] %}
@@ -136,6 +142,12 @@ platform:
 {% if 'root_device_hint' in hostvars[host] and 'root_device_hint_value' in hostvars[host] %}
         rootDeviceHints:
           {{ hostvars[host]['root_device_hint'] }}: {{ hostvars[host]['root_device_hint_value'] }}
+{% endif %}
+{% endif %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) %}
+{% if rendered_worker_nmstate_yml is defined and rendered_worker_nmstate_yml|length %}
+        networkConfig:
+{{ rendered_worker_nmstate_yml | indent(10, true) }}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
@@ -101,9 +101,9 @@ platform:
 {% endif %}
 {% endif %}
 {% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) %}
-{% if rendered_master_nmstate_yml is defined and rendered_master_nmstate_yml|length %}
+{% if master_network_config_template is defined %}
         networkConfig:
-{{ rendered_master_nmstate_yml | indent(10, true) }}
+{{ lookup('template', master_network_config_template, template_vars=hostvars[host]) | indent(10, true) }}
 {% endif %}
 {% endif %}
 {% endfor %}
@@ -145,9 +145,9 @@ platform:
 {% endif %}
 {% endif %}
 {% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) %}
-{% if rendered_worker_nmstate_yml is defined and rendered_worker_nmstate_yml|length %}
+{% if worker_network_config_template is defined %}
         networkConfig:
-{{ rendered_worker_nmstate_yml | indent(10, true) }}
+{{ lookup('template', worker_network_config_template, template_vars=hostvars[host]) | indent(10, true) }}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -104,9 +104,9 @@ platform:
 {% endif %}
 {% endif %}
 {% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) %}
-{% if rendered_master_nmstate_yml is defined and rendered_master_nmstate_yml|length %}
+{% if master_network_config_template is defined %}
         networkConfig:
-{{ rendered_master_nmstate_yml | indent(10, true) }}
+{{ lookup('template', master_network_config_template, template_vars=hostvars[host]) | indent(10, true) }}
 {% endif %}
 {% endif %}
 {% endfor %}
@@ -146,9 +146,9 @@ platform:
 {% endif %}
 {% endif %}
 {% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) %}
-{% if rendered_worker_nmstate_yml is defined and rendered_worker_nmstate_yml|length %}
+{% if worker_network_config_template is defined %}
         networkConfig:
-{{ rendered_worker_nmstate_yml | indent(10, true) }}
+{{ lookup('template', worker_network_config_template, template_vars=hostvars[host]) | indent(10, true) }}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -103,6 +103,12 @@ platform:
           {{ hostvars[host]['root_device_hint'] }}: {{ hostvars[host]['root_device_hint_value'] }}
 {% endif %}
 {% endif %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) %}
+{% if rendered_master_nmstate_yml is defined and rendered_master_nmstate_yml|length %}
+        networkConfig:
+{{ rendered_master_nmstate_yml | indent(10, true) }}
+{% endif %}
+{% endif %}
 {% endfor %}
 {% if groups['workers'] is defined %}
 {% for host in groups['workers'] %}
@@ -137,6 +143,12 @@ platform:
 {% if 'root_device_hint' in hostvars[host] and 'root_device_hint_value' in hostvars[host] %}
         rootDeviceHints:
           {{ hostvars[host]['root_device_hint'] }}: {{ hostvars[host]['root_device_hint_value'] }}
+{% endif %}
+{% endif %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) %}
+{% if rendered_worker_nmstate_yml is defined and rendered_worker_nmstate_yml|length %}
+        networkConfig:
+{{ rendered_worker_nmstate_yml | indent(10, true) }}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -480,22 +480,42 @@
   - always
   - validation
 
-- name: "Set rendered_master_nmstate_yml from raw value for master nodes"
-  set_fact:
-    rendered_master_nmstate_yml: "{{ master_network_config_raw | to_yaml | trim }}"
-  when: master_network_config_raw is defined
+- name: Verify if master_network_config_template is defined and exists
+  stat:
+    path: "{{ master_network_config_template }}"
+    get_checksum: false
+  register: master_nm_template
+  when: master_network_config_template is defined
+  tags:
+  - always
+  - validation
 
-- name: "Set rendered_master_nmstate_yml from file for master nodes"
-  set_fact:
-    rendered_master_nmstate_yml: "{{ lookup('file', master_network_config_file) }}"
-  when: master_network_config_file is defined
+- name: Fail when master_network_config_template is defined but not exists
+  fail:
+    msg: "Variable master_network_config_template is defined but path does not exists"
+  when:
+    - master_network_config_template is defined
+    - not master_nm_template.exists|bool
+  tags:
+  - always
+  - validation
 
-- name: "Set rendered_worker_nmstate_yml from raw value for worker nodes"
-  set_fact:
-    rendered_worker_nmstate_yml: "{{ worker_network_config_raw | to_yaml | trim }}"
-  when: worker_network_config_raw is defined
+- name: Verify if worker_network_config_template is defined and exists
+  stat:
+    path: "{{ worker_network_config_template }}"
+    get_checksum: false
+  register: worker_nm_template
+  when: worker_network_config_template is defined
+  tags:
+  - always
+  - validation
 
-- name: "Set rendered_worker_nmstate_yml from file for worker nodes"
-  set_fact:
-    rendered_worker_nmstate_yml: "{{ lookup('file', worker_network_config_file) }}"
-  when: worker_network_config_file is defined
+- name: Fail when worker_network_config_template is defined but not exists
+  fail:
+    msg: "Variable worker_network_config_template is defined but path does not exists"
+  when:
+    - worker_network_config_template is defined
+    - not worker_nm_template.exists|bool
+  tags:
+  - always
+  - validation

--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -492,7 +492,7 @@
 
 - name: "Set rendered_worker_nmstate_yml from raw value for worker nodes"
   set_fact:
-    rendered_master_nmstate_yml: "{{ worker_network_config_raw | to_yaml | trim }}"
+    rendered_worker_nmstate_yml: "{{ worker_network_config_raw | to_yaml | trim }}"
   when: worker_network_config_raw is defined
 
 - name: "Set rendered_worker_nmstate_yml from file for worker nodes"

--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -495,7 +495,7 @@
     msg: "Variable master_network_config_template is defined but path does not exists"
   when:
     - master_network_config_template is defined
-    - not master_nm_template.exists|bool
+    - not master_nm_template.stat.exists|bool
   tags:
   - always
   - validation
@@ -515,7 +515,7 @@
     msg: "Variable worker_network_config_template is defined but path does not exists"
   when:
     - worker_network_config_template is defined
-    - not worker_nm_template.exists|bool
+    - not worker_nm_template.stat.exists|bool
   tags:
   - always
   - validation

--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -497,5 +497,5 @@
 
 - name: "Set rendered_worker_nmstate_yml from file for worker nodes"
   set_fact:
-    rendered_master_nmstate_yml: "{{ lookup('file', worker_network_config_file) }}"
+    rendered_worker_nmstate_yml: "{{ lookup('file', worker_network_config_file) }}"
   when: worker_network_config_file is defined

--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -479,3 +479,23 @@
   tags:
   - always
   - validation
+
+- name: "Set rendered_master_nmstate_yml from raw value for master nodes"
+  set_fact:
+    rendered_master_nmstate_yml: "{{ master_network_config_raw | to_yaml | trim }}"
+  when: master_network_config_raw is defined
+
+- name: "Set rendered_master_nmstate_yml from file for master nodes"
+  set_fact:
+    rendered_master_nmstate_yml: "{{ lookup('file', master_network_config_file) }}"
+  when: master_network_config_file is defined
+
+- name: "Set rendered_worker_nmstate_yml from raw value for worker nodes"
+  set_fact:
+    rendered_master_nmstate_yml: "{{ worker_network_config_raw | to_yaml | trim }}"
+  when: worker_network_config_raw is defined
+
+- name: "Set rendered_worker_nmstate_yml from file for worker nodes"
+  set_fact:
+    rendered_master_nmstate_yml: "{{ lookup('file', worker_network_config_file) }}"
+  when: worker_network_config_file is defined

--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -485,6 +485,7 @@
     path: "{{ master_network_config_template }}"
     get_checksum: false
   register: master_nm_template
+  delegate_to: localhost
   when: master_network_config_template is defined
   tags:
   - always
@@ -505,6 +506,7 @@
     path: "{{ worker_network_config_template }}"
     get_checksum: false
   register: worker_nm_template
+  delegate_to: localhost
   when: worker_network_config_template is defined
   tags:
   - always

--- a/documentation/ipi-install/ipi-install-configuration-files.adoc
+++ b/documentation/ipi-install/ipi-install-configuration-files.adoc
@@ -41,3 +41,7 @@ endif::[]
 ifeval::[{product-version} > 4.7]
 include::modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc[leveloffset=+1]
 endif::[]
+
+ifeval::[{product-version} > 4.9]
+include::modules/ipi-install-modifying-install-config-for-nmstate-network-config-day1.adoc[leveloffset=+1]
+endif::[]

--- a/documentation/ipi-install/modules/ipi-install-modifying-install-config-for-nmstate-network-config-day1.adoc
+++ b/documentation/ipi-install/modules/ipi-install-modifying-install-config-for-nmstate-network-config-day1.adoc
@@ -6,7 +6,7 @@
 
 = Modifying the `install-config.yaml` file to add network config with NMstate at day1 (optional)
 
-1. To deploy an {product-title} cluster with NMstate network config, create an NMState YAML file `nmstate_yaml_file` file.
+1. To deploy an {product-title} cluster with NMstate network config, create an NMState YAML file `nmstate_yaml_file`.
 
 [source,yaml]
 ----

--- a/documentation/ipi-install/modules/ipi-install-modifying-install-config-for-nmstate-network-config-day1.adoc
+++ b/documentation/ipi-install/modules/ipi-install-modifying-install-config-for-nmstate-network-config-day1.adoc
@@ -1,0 +1,86 @@
+// This is included in the following assemblies:
+//
+// ipi-install-configuration-files.adoc
+
+[id='modifying-install-config-for-nmstate-network-config-day1_{context}']
+
+= Modifying the `install-config.yaml` file to add network config with NMstate at day1 (optional)
+
+1. To deploy an {product-title} cluster with NMstate network config, create an NMState YAML file `nmstate_yaml_file` file.
+
+[source,yaml]
+----
+interfaces:
+- name: <nic1_name>
+  type: ethernet
+  state: up
+  ipv4:
+    address:
+    - ip: <ip_address>
+      prefix-length: 24
+    enabled: true
+dns-resolver:
+  config:
+    server:
+    - <dns_ip_address>
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: <next_hop_ip_address>
+    next-hop-interface: <next_hop_nic1_name>
+----
+
+NOTE: Replace <nic1_name>, <ip_address>, <dns_ip_address>, <next_hop_ip_address> and <next_hop_nic1_name> with appropriate values.
+
+[IMPORTANT]
+====
+Consider installing `nmstate` package and testing the NMState syntax with `nmstatectl gc` before including it in the install-config.yaml file, because the installer will not check the NMState YAML syntax
+====
+
+2. Test the configuration file by running the following command: (Replace <nmstate_yaml_file> with the configuration file name)
+
+[source,bash]
+----
+$ nmstatectl gc <nmstate_yaml_file>
+----
+
+3. Use the networkConfig configuration setting by adding the NMState configuration to hosts within the install-config.yaml file:
+[source,yaml]
+----
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish+http://<out_of_band_ip>/redfish/v1/Systems/
+          username: <user>
+          password: <password>
+          disableCertificateVerification: null
+        bootMACAddress: <NIC1_mac_address>
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: "/dev/sda"
+        networkConfig:
+          interfaces:
+          - name: <nic1_name>
+            type: ethernet
+            state: up
+            ipv4:
+              address:
+              - ip: <ip_address>
+                prefix-length: 24
+              enabled: true
+          dns-resolver:
+            config:
+              server:
+              - <dns_ip_address>
+          routes:
+            config:
+            - destination: 0.0.0.0/0
+              next-hop-address: <next_hop_ip_address>
+              next-hop-interface: <next_hop_nic1_name>
+----
+
+[IMPORTANT]
+====
+After deploying the cluster, you cannot modify the networkConfig configuration setting of install-config.yaml file to make changes to the host network interface. Use the Kubernetes NMState Operator to make changes to the host network interface after deployment.
+====

--- a/features/kubernetes-nmstate/day1/README.md
+++ b/features/kubernetes-nmstate/day1/README.md
@@ -1,61 +1,143 @@
-When using [baremetal_repo](https://github.com/openshift-kni/baremetal-deploy) repository to deploy a cluster you can pass the `networkConfig` settings using two forms:
+When using [baremetal_repo](https://github.com/openshift-kni/baremetal-deploy) repository to deploy a cluster you can pass the `networkConfig` settings using YAML files per role: master and worker, such YAML files could optionally include jinja format, and in combination of variables from the respective nodes in the inventory it is possible to render settings per node as desired. The steps to prepare are the following:
 
-a) If you wish to use your own NMState YAML file as created above, you can set `master_network_config_file` and `worker_network_config_file` variables pointing to a path to your desired configuration:
+1) Set `master_network_config_template` and `worker_network_config_template` variables pointing to a path to your desired configuration:
 
-As YAML as extra-variables in your deployment:
-
-```yaml
-master_network_config_file: "/path/to/your/master_nmstate_file.yaml"
-worker_network_config_file: "/path/to/your/worker_nmstate_file.yaml"
-```
-
-As JSON in your inventory file:
-
-```
-master_network_config_file="/path/to/your/master_nmstate_file.yaml"
-worker_network_config_file="/path/to/your/worker_nmstate_file.yaml"
-```
-
-b) If you wish to provide the `networkConfig` settings in a raw YAML variable, you can use the `master_network_config_raw` and `worker_network_config_raw` variables and pass them as extra-variables in your deployment.
+include the following ansible extra-variables in your deployment:
 
 ```yaml
-master_network_config_raw:
-  interfaces:
-  - name: <nic1_name>
-    type: ethernet
-    state: up
-    ipv4:
-      address:
-      - ip: <ip_address>
-        prefix-length: 24
-      enabled: true
-  dns-resolver:
-    config:
-      server:
-      - <dns_ip_address>
-  routes:
-    config:
-    - destination: 0.0.0.0/0
-      next-hop-address: <next_hop_ip_address>
-      next-hop-interface: <next_hop_nic1_name>
+master_network_config_template: "/path/to/your/master_nmstate_file.yaml"
+worker_network_config_template: "/path/to/your/worker_nmstate_file.yaml"
+```
 
-worker_network_config_raw:
-  interfaces:
-  - name: <nic1_name>
-    type: ethernet
-    state: up
-    ipv4:
-      address:
-      - ip: <ip_address>
-        prefix-length: 24
-      enabled: true
-  dns-resolver:
-    config:
-      server:
-      - <dns_ip_address>
-  routes:
-    config:
-    - destination: 0.0.0.0/0
-      next-hop-address: <next_hop_ip_address>
-      next-hop-interface: <next_hop_nic1_name>
+2) Include NMstate settings in YAML format for each role of nodes: master and workers, in the files of step 1. For example:
+
+Content example of file `master_network_config_template`:
+```yaml
+interfaces:
+- ipv4:
+    auto-dns: true
+    dhcp: true
+    enabled: true
+  ipv6:
+    dhcp: false
+    enabled: false
+  link-aggregation:
+    mode: 802.3ad
+    options:
+      miimon: 100
+      mode: 802.3ad
+    port:
+    - ens1f0
+    - ens1f1
+  mtu: 9000
+  name: bond0
+  state: up
+  type: bond
+```
+
+Content example of file `worker_network_config_template`:
+```yaml
+interfaces:
+- ipv4:
+    auto-dns: true
+    dhcp: true
+    enabled: true
+  ipv6:
+    dhcp: false
+    enabled: false
+  link-aggregation:
+    mode: 802.3ad
+    options:
+      miimon: 100
+      mode: 802.3ad
+    port:
+    - ens1f0
+    - ens1f1
+  mtu: 9000
+  name: bond0
+  state: up
+  type: bond
+- ipv4:
+    auto-gateway: false
+    auto-routes: false
+    dhcp: true
+    enabled: true
+  ipv6:
+    auto-gateway: false
+    dhcp: false
+    enabled: false
+  mtu: 9000
+  name: bond0.100
+  state: up
+  type: vlan
+  vlan:
+    base-iface: bond0
+    id: 100
+```
+
+The same settings will be used for all nodes of the same role (masters and workers), then it is possible to use jinja format in the content of those files to customize settings per node. This is an example:
+
+Content example of file `master_network_config_template` with jinja expressions:
+```yaml
+interfaces:
+- name: eno2
+  type: ethernet
+  state: up
+  ipv4:
+    address:
+    - ip: {{ static_ip.split('/')[0] }}
+      prefix-length: {{ static_ip.split('/')[1] }}
+    enabled: true
+dns-resolver:
+  config:
+    server:
+    - 192.168.0.2
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.168.0.1
+    next-hop-interface: eno2
+```
+
+Content example of file `worker_network_config_template` with jinja expressions:
+```yaml
+interfaces:
+- name: eno2
+  type: ethernet
+  state: up
+  ipv4:
+    address:
+    - ip: {{ static_ip.split('/')[0] }}
+      prefix-length: {{ static_ip.split('/')[1] }}
+    enabled: true
+- name: eno3
+  type: ethernet
+  state: up
+  ipv4:
+    enabled: true
+    auto-dns: true
+    dhcp: true
+dns-resolver:
+  config:
+    server:
+    - 192.168.0.2
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.168.0.1
+    next-hop-interface: eno2
+```
+
+
+Finally in your inventory you can add variables per node, and they will be rendered from the templates provided. In this example `static_ip` variable will be rendered per node of each role, but you can include more variables if desired.
+```json
+[masters]
+master-0 name=master-0 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.1 ipmi_port=623 provision_mac=ec:f4:bb:da:0c:58 static_ip="192.168.0.11/24"
+master-1 name=master-1 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.2 ipmi_port=623 provision_mac=ec:f4:bb:da:32:88 static_ip="192.168.0.12/24"
+master-2 name=master-2 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.3 ipmi_port=623 provision_mac=ec:f4:bb:da:0d:98 static_ip="192.168.0.13/24"
+
+# Worker nodes
+[workers]
+worker-0 name=worker-0 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.4 ipmi_port=623 provision_mac=ec:f4:bb:da:0c:18 static_ip="192.168.0.14/24"
+worker-1 name=worker-1 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.5 ipmi_port=623 provision_mac=ec:f4:bb:da:32:28 static_ip="192.168.0.15/24"
 ----

--- a/features/kubernetes-nmstate/day1/README.md
+++ b/features/kubernetes-nmstate/day1/README.md
@@ -130,7 +130,7 @@ routes:
 
 
 Finally in your inventory you can add variables per node, and they will be rendered from the templates provided. In this example `static_ip` variable will be rendered per node of each role, but you can include more variables if desired.
-```json
+```
 [masters]
 master-0 name=master-0 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.1 ipmi_port=623 provision_mac=ec:f4:bb:da:0c:58 static_ip="192.168.0.11/24"
 master-1 name=master-1 role=master ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.2 ipmi_port=623 provision_mac=ec:f4:bb:da:32:88 static_ip="192.168.0.12/24"
@@ -140,4 +140,4 @@ master-2 name=master-2 role=master ipmi_user=admin ipmi_password=password ipmi_a
 [workers]
 worker-0 name=worker-0 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.4 ipmi_port=623 provision_mac=ec:f4:bb:da:0c:18 static_ip="192.168.0.14/24"
 worker-1 name=worker-1 role=worker ipmi_user=admin ipmi_password=password ipmi_address=192.168.1.5 ipmi_port=623 provision_mac=ec:f4:bb:da:32:28 static_ip="192.168.0.15/24"
-----
+```

--- a/features/kubernetes-nmstate/day1/README.md
+++ b/features/kubernetes-nmstate/day1/README.md
@@ -1,0 +1,61 @@
+When using [baremetal_repo](https://github.com/openshift-kni/baremetal-deploy) repository to deploy a cluster you can pass the `networkConfig` settings using two forms:
+
+a) If you wish to use your own NMState YAML file as created above, you can set `master_network_config_file` and `worker_network_config_file` variables pointing to a path to your desired configuration:
+
+As YAML as extra-variables in your deployment:
+
+```yaml
+master_network_config_file: "/path/to/your/master_nmstate_file.yaml"
+worker_network_config_file: "/path/to/your/worker_nmstate_file.yaml"
+```
+
+As JSON in your inventory file:
+
+```
+master_network_config_file="/path/to/your/master_nmstate_file.yaml"
+worker_network_config_file="/path/to/your/worker_nmstate_file.yaml"
+```
+
+b) If you wish to provide the `networkConfig` settings in a raw YAML variable, you can use the `master_network_config_raw` and `worker_network_config_raw` variables and pass them as extra-variables in your deployment.
+
+```yaml
+master_network_config_raw:
+  interfaces:
+  - name: <nic1_name>
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: <ip_address>
+        prefix-length: 24
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - <dns_ip_address>
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: <next_hop_ip_address>
+      next-hop-interface: <next_hop_nic1_name>
+
+worker_network_config_raw:
+  interfaces:
+  - name: <nic1_name>
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: <ip_address>
+        prefix-length: 24
+      enabled: true
+  dns-resolver:
+    config:
+      server:
+      - <dns_ip_address>
+  routes:
+    config:
+    - destination: 0.0.0.0/0
+      next-hop-address: <next_hop_ip_address>
+      next-hop-interface: <next_hop_nic1_name>
+----

--- a/features/kubernetes-nmstate/day1/README.md
+++ b/features/kubernetes-nmstate/day1/README.md
@@ -2,7 +2,7 @@ When using [baremetal_repo](https://github.com/openshift-kni/baremetal-deploy) r
 
 1) Set `master_network_config_template` and `worker_network_config_template` variables pointing to a path to your desired configuration:
 
-include the following ansible extra-variables in your deployment:
+include the following ansible extra-variables in your deployment. The files need to be located in the Ansible controller server:
 
 ```yaml
 master_network_config_template: "/path/to/your/master_nmstate_file.yaml"


### PR DESCRIPTION
This patch allows to include NMstate network settings in the install-config.yaml file and setup custom
networking at day1

# Description

The change allows to pass `networkConfig` settings in YAML for OCP nodes in the install-config.yaml file via two possible ways, either by loading configurations from specified files, or by defining the variables in yaml format.
This feature is available since OCP 4.10 and we want to have an additional option to setup networking besides creating machine-config manifests with NetworkManager connections.

Fixes #909 

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

OCP Deployment Tests are performed in CI Labs, to validate:
- [x] The change does not introduce issues without the settings in both OCP >= 4.10 and below
- [x] The NMstate settings are passed to the install-config.yaml and clusters are deployed using custom network config for  OCP >= 4.10

**Test Configuration**:

- Versions: OCP 4.8, 4.9, 4.10, 4.11
- Hardware: Baremetal HP ProLiant DL360 Gen10

## Checklist

- [x] I have performed a self-review of my own code
- [x] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] Documented in the inventory/hosts.sample
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [x] PRs should not be merged unless positively reviewed.
