### PR TITLE
Added property addr_gen_mode6 to task creating the provisioning bridge

### DIFF
--- a/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
@@ -62,6 +62,7 @@
         autoconnect: yes
         ip4_method: manual
         ip6_method: disabled
+        addr_gen_mode6: eui64
         stp: off
         ip4: "{{ prov_bridge_ip | default('172.22.0.1/21') }}"
         state: present

--- a/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/40_bridge.yml
@@ -55,7 +55,7 @@
         - prov_network is defined and prov_network
 
     - name: Create Bridge labeled provisioning bridge ipv4
-      nmcli:
+      community.general.nmcli:
         conn_name: "{{ provisioning_bridge }}"
         type: bridge
         ifname: "{{ provisioning_bridge }}"


### PR DESCRIPTION
# Description

Adding property addr_gen_mode6 to task "Create Bridge labeled provisioning bridge ipv4".

Fixes: https://www.distributed-ci.io/jobs/5f627331-35af-43ff-adfd-fd00767458e5/jobStates?sort=date&task=0bfe2eb4-097d-493a-be19-c156e8e7b442

## Type of change

Please select the appropriate options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Run DCI job in Telco CI Dallas lab, where issue is known to happen.
- Run DCI job in Telco CI BOS2 lab, where issue is known not to happen.

**Test Configuration**:

- Versions: OCP-4.10

## Checklist

- [x] I have performed a self-review of my own code
- [-] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
