### PR TITLE
Prefix temp directories with baremetal-deploy to avoid permission issues

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/10_get_oc.yml
+++ b/ansible-ipi-install/roles/installer/tasks/10_get_oc.yml
@@ -10,7 +10,7 @@
 - name: Find any old tmp dirs with OpenShift related binaries
   find:
     paths: /tmp
-    patterns: 'ansible.*'
+    patterns: "baremetal-deploy.*"
     file_type: directory
   register: tmp_results
   tags:
@@ -48,6 +48,7 @@
 - name: Create tmp directory to store OpenShift binaries
   tempfile:
     state: directory
+    prefix: "baremetal-deploy."
     suffix: "{{ release_version }}"
   register: tempdiroutput
   tags: getoc
@@ -60,6 +61,7 @@
 - name: Create tmp directory to store OpenShift binaries on registry host
   tempfile:
     state: directory
+    prefix: "baremetal-deploy."
     suffix: "{{ release_version }}"
   register: registryhost_tempdir
   when: registry_creation|bool

--- a/ansible-ipi-install/roles/installer/tasks/15_disconnected_registry_create.yml
+++ b/ansible-ipi-install/roles/installer/tasks/15_disconnected_registry_create.yml
@@ -2,7 +2,7 @@
 - name: Find any old tmp dirs with OpenShift related binaries on registry host
   find:
     paths: /tmp
-    patterns: 'ansible.*'
+    patterns: "baremetal-deploy.*"
     file_type: directory
   register: registry_tmp_results
   when: groups['registry_host'][0] != groups['provisioner'][0]
@@ -75,6 +75,7 @@
 - name: Create tmp directory to store OpenShift binaries on registry host
   tempfile:
     state: directory
+    prefix: "baremetal-deploy."
     suffix: "{{ release_version }}"
   register: registry_tempdir
   delegate_to: "{{ groups['registry_host'][0] }}"


### PR DESCRIPTION
baremetal-deploy downloads OpenShift binaries in a `/tmp/ansible.xxxx` folder using the tempfile ansible module. baremetal-deploy also remove all `/tmp/ansible.xxxx` folders before downloading those binaries. cf https://github.com/openshift-kni/baremetal-deploy/blob/47e20e26595fcf7696d7a6414cf4acb2af683a6e/ansible-ipi-install/roles/installer/tasks/10_get_oc.yml This is weird to me, but I may miss some context here.

The problem is baremetal-deploy is used by other ansible code that may use the tempfile ansible module with a user different than `kni`. The deletion of the folders will fail because of permission issue.

This patch prefix the temp folder with baremetal-deploy. Binaries will be downloaded in `/tmp/baremetal-deploy.xxxx` temp folder.

Fixes: https://github.com/openshift-kni/baremetal-deploy/issues/922
