### PR TITLE
Add support to dualstack vips starting in 4.12

### DIFF
--- a/ansible-ipi-install/inventory/hosts.sample
+++ b/ansible-ipi-install/inventory/hosts.sample
@@ -71,6 +71,10 @@ prov_ip=172.22.0.3
 # Only one of ipv4_baremetal and dualstack_baremetal can be true
 #dualstack_baremetal=False
 
+# (Optional) When ipv6_enabled and dualstack_baremetal are set to True, and want dual-stack VIPs for baremetal network
+# Requires that the API and Ingress VIPs resolve both A and AAAA DNS records
+#dualstack_vips=False
+
 # (Optional) A list of clock servers to be used in chrony by the masters and workers
 #clock_servers=["pool.ntp.org","clock.redhat.com"]
 
@@ -133,9 +137,15 @@ extcidrnet6=""
 # An IP reserved on the baremetal network for the API endpoint.
 # (Optional) If not set, a DNS lookup verifies that api.<clustername>.<domain> provides an IP
 #apivip=""
+# An IP reserved on the baremetal network for the API IPv6 endpoint.
+# (Optional) Starting in OCP 4.12. IPv6 from DNS lookup of api.<clustername>.<domain>
+#apivip6=""
 # An IP reserved on the baremetal network for the Ingress endpoint.
 # (Optional) If not set, a DNS lookup verifies that *.apps.<clustername>.<domain> provides an IP
 #ingressvip=""
+# An IP reserved on the baremetal network for the Ingress IPv6 endpoint.
+# (Optional) Starting in OCP 4.12. IPv6 from DNS lookup of *.apps.<clustername>.<domain>
+#ingressvip6=""
 # The master hosts provisioning nic
 # (Optional) If not set, the prov_nic will be used
 #masters_prov_nic=""

--- a/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
@@ -46,8 +46,25 @@ controlPlane:
     baremetal: {}
 platform:
   baremetal:
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 12)) and dualstack_baremetal|bool and dualstack_vips|bool %}
+    apiVIPs:
+{% if apivip is defined and apivip|ipv4 %}
+      - {{ apivip }}
+{% endif %}
+{% if ipv6_enabled|bool and apivip6 is defined and apivip6|ipv6 %}
+      - {{ apivip6 }}
+{% endif %}
+    ingressVIPs:
+{% if ingressvip is defined and ingressvip|ipv4 %}
+      - {{ ingressvip }}
+{% endif %}
+{% if ipv6_enabled|bool and ingressvip6 is defined and ingressvip6|ipv6 %}
+      - {{ ingressvip6 }}
+{% endif %}
+{% else %}
     apiVIP: {{ apivip }}
     ingressVIP: {{ ingressvip }}
+{% endif %}
 {% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 5)) %}
     dnsVIP: {{ dnsvip }}
 {% endif %}

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -46,8 +46,25 @@ controlPlane:
     baremetal: {}
 platform:
   baremetal:
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 12)) and dualstack_baremetal|bool and dualstack_vips|bool %}
+    apiVIPs:
+{% if apivip is defined and apivip|ipv4 %}
+      - {{ apivip }}
+{% endif %}
+{% if ipv6_enabled|bool and apivip6 is defined and apivip6|ipv6 %}
+      - {{ apivip6 }}
+{% endif %}
+    ingressVIPs:
+{% if ingressvip is defined and ingressvip|ipv4 %}
+      - {{ ingressvip }}
+{% endif %}
+{% if ipv6_enabled|bool and ingressvip6 is defined and ingressvip6|ipv6 %}
+      - {{ ingressvip6 }}
+{% endif %}
+{% else %}
     apiVIP: {{ apivip }}
     ingressVIP: {{ ingressvip }}
+{% endif %}
 {% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 5)) %}
     dnsVIP: {{ dnsvip }}
 {% endif %}

--- a/ansible-ipi-install/roles/node-prep/defaults/main.yml
+++ b/ansible-ipi-install/roles/node-prep/defaults/main.yml
@@ -11,6 +11,7 @@ https_proxy: ""
 ipv4_baremetal: false
 ipv4_provisioning: false
 dualstack_baremetal: false
+dualstack_vips: false
 provisioning_bridge: "provisioning"
 webserver_url: ""
 baremetal_bridge: "baremetal"

--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -138,6 +138,57 @@
     - always
     - validation
 
+- name: Validations for IPv6 VIPs in OCP >= 4.12
+  block:
+    - name: Verify DNS records for Wildcard (Ingress) IPv6 VIP
+      set_fact:
+        ingressvip6: "{{ lookup('dig', 'foo.apps.{{ cluster |quote }}.{{ domain | quote }}.', 'qtype=AAAA' ) }}"
+      when: ((ingressvip6 is undefined) or (ingressvip6|length == 0))
+      tags:
+        - always
+        - validation
+
+    - name: Verify DNS records for API IPv6 VIP
+      set_fact:
+        apivip6: "{{ lookup('dig', 'api.{{ cluster |quote }}.{{ domain | quote }}.', 'qtype=AAAA' ) }}"
+      when: ((apivip6 is undefined) or (apivip6|length == 0))
+      tags:
+        - always
+        - validation
+
+    - name: Display API IPv6 VIP
+      debug:
+        msg: "The API IPv6 VIP is {{ apivip6 }}"
+        verbosity: 2
+      tags: validation
+
+    - name: Display Ingress IPv6 VIP
+      debug:
+        msg: "The Wildcard (Ingress) IPv6 VIP is {{ ingressvip6 }}"
+        verbosity: 2
+      tags: validation
+
+    - name: Fail if incorrect API IPv6 VIP
+      fail:
+        msg: "The API IPv6 VIP seems to be incorrect. Value was NXDOMAIN or empty string."
+      when: (apivip6 == 'NXDOMAIN') or (apivip6|length == 0)
+      tags:
+        - always
+        - validation
+
+    - name: Fail if incorrect Ingress IPv6 VIP
+      fail:
+        msg: "The Ingress IPv6 VIP seems to be incorrect. Value was NXDOMAIN or empty string."
+      when: (ingressvip6 == 'NXDOMAIN') or (ingressvip6|length == 0)
+      tags:
+        - always
+        - validation
+  when:
+    - version.split('.')[0]|int == 4 and version.split('.')[1]|int >= 12
+    - ipv6_enabled | bool
+    - dualstack_baremetal | bool
+    - dualstack_vips | bool
+
 - name: Set release_url for development envs
   set_fact:
     release_url: "{{ (webserver_url|length) | ternary(webserver_url, 'https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview') }}"


### PR DESCRIPTION
Add support to specify dual-stack VIPs starting in 4.12

# Description

This patch allows to specify IPv4 and IPv6 VIPs for Ingress and API using dualstack_vips boolean.
Validations are included and if not specify it, then it defaults to old variables to specify a single VIP for Ingress and API.

Fixes #952 

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

OCP Deployment Tests are performed in CI Labs, to validate:
- [x] The change does not introduce issues in any supported version of OCP
- [x] The change is only applied in OCP >= 4.12 when boleean `dualstack_vips` is defined as `true`
- [x] If dualstack_vips boolean is not defined in OCP >= 4.12, the old method with a single VIP still works. 

**Test Configuration**:

- Versions: OCP 4.9, 4.10, 4.11, and 4.12
- Hardware: Baremetal HP ProLiant DL360 Gen10

## Checklist

- [x] I have performed a self-review of my own code
- [x] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
