### PR TITLE
Add retries to get the ocp clients

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/10_get_oc.yml
+++ b/ansible-ipi-install/roles/installer/tasks/10_get_oc.yml
@@ -89,6 +89,10 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: '0755'
+  register: result
+  retries: 3
+  delay: 10
+  until: result is not failed
   delegate_to: "{{ registry_creation | ternary(groups['registry_host'][0], groups['provisioner'][0]) }}"
   tags: getoc
 

--- a/ansible-ipi-install/roles/installer/tasks/20_extract_installer.yml
+++ b/ansible-ipi-install/roles/installer/tasks/20_extract_installer.yml
@@ -116,6 +116,10 @@
   get_url:
     url: "{{ webserver_url }}/{{ version }}/openshift-baremetal-install"
     dest: "{{ tempdir }}/openshift-baremetal-install"
+  register: result
+  retries: 3
+  delay: 10
+  until: result is not failed
   when: (the_url.status == -1 and disconnected_installer|length == 0)
   tags:
     - extract


### PR DESCRIPTION
For some network reasons the client downloads can failed, this change retries three times to download them.

It is a bug fix for environments with potential network issues.
