### PR TITLE
Add support for wwnVendorExtension & wwnWithExtension as disk hints

### DIFF
--- a/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
@@ -114,7 +114,7 @@ platform:
 {% endif %}
 {% if 'root_device_hint' in hostvars[host] and 'root_device_hint_value' in hostvars[host] and hostvars[host]['root_device_hint'] in roothint_list %}
         rootDeviceHints:
-          {{ hostvars[host]['root_device_hint'] }}: {{ hostvars[host]['root_device_hint_value'] }}
+          {{ hostvars[host]['root_device_hint'] }}: '{{ hostvars[host]['root_device_hint_value'] }}'
 {% endif %}
 {% endif %}
 {% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) %}

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -120,7 +120,7 @@ platform:
 {% endif %}
 {% if 'root_device_hint' in hostvars[host] and 'root_device_hint_value' in hostvars[host] and hostvars[host]['root_device_hint'] in roothint_list %}
         rootDeviceHints:
-          {{ hostvars[host]['root_device_hint'] }}: {{ hostvars[host]['root_device_hint_value'] }}
+          {{ hostvars[host]['root_device_hint'] }}: '{{ hostvars[host]['root_device_hint_value'] }}'
 {% endif %}
 {% endif %}
 {% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) %}

--- a/ansible-ipi-install/roles/node-prep/vars/main.yml
+++ b/ansible-ipi-install/roles/node-prep/vars/main.yml
@@ -40,5 +40,7 @@ roothint_list:
   - serialNumber
   - minSizeGigabytes
   - wwn
+  - wwnWithExtension
+  - wwnVendorExtension
   - rotational
   - ''


### PR DESCRIPTION
# Description

* $subject
* Add quotes around disk hint value, in case the value in format of "0x1234" when using the disk wwn values.

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [X] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
