### PR TITLE
Add missing quotes for drive hint in workers group

### DIFF
--- a/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
@@ -158,7 +158,7 @@ platform:
 {% endif %}
 {% if 'root_device_hint' in hostvars[host] and 'root_device_hint_value' in hostvars[host] %}
         rootDeviceHints:
-          {{ hostvars[host]['root_device_hint'] }}: {{ hostvars[host]['root_device_hint_value'] }}
+          {{ hostvars[host]['root_device_hint'] }}: '{{ hostvars[host]['root_device_hint_value'] }}'
 {% endif %}
 {% endif %}
 {% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) %}

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -162,7 +162,7 @@ platform:
 {% endif %}
 {% if 'root_device_hint' in hostvars[host] and 'root_device_hint_value' in hostvars[host] %}
         rootDeviceHints:
-          {{ hostvars[host]['root_device_hint'] }}: {{ hostvars[host]['root_device_hint_value'] }}
+          {{ hostvars[host]['root_device_hint'] }}: '{{ hostvars[host]['root_device_hint_value'] }}'
 {% endif %}
 {% endif %}
 {% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) %}


### PR DESCRIPTION
# Description

This compliments the changes I did in #960, but missed the worker's group.
