### PR TITLE
Introduce the use of imageDigestSources

### DIFF
--- a/ansible-ipi-install/roles/installer/templates/install-config-appends.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config-appends.j2
@@ -1,6 +1,10 @@
 additionalTrustBundle: |
   {{ trustbundle | regex_replace('\n', '\n  ') }}
+{% if release_version is version('4.14', '<') %}
 imageContentSources:
+{% else %}
+imageDigestSources:
+{% endif %}
 - mirrors:
   - {{ local_registry }}/{{ local_repo }}
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev

--- a/documentation/ansible-playbook/modules/ansible-playbook-using-an-existing-registry.adoc
+++ b/documentation/ansible-playbook/modules/ansible-playbook-using-an-existing-registry.adoc
@@ -36,7 +36,8 @@ Example:
 ====
 
 The `disconnected_registry_mirrors_file` variable should point to a file
-containing the `additionalTrustBundle` and `imageContentSources` for
+containing the `additionalTrustBundle` and `imageContentSources` (OpenShift
+4.13 and below) or `imageDigestSources` (OpenShift 4.14 and above) for
 the disconnected registry. The certificate that goes within the additional
 trust bundle is the disconnected registry node's certificate. The
 `imageContentSources` adds the mirrored information of the registry. The below
@@ -58,7 +59,7 @@ additionalTrustBundle: |
   dC5jb20wHhcNMjAwNDA3MjM1MzI2WhcNMzAwNDA1MjM1MzI2WjCBkDELMAkGA1UE
   -----END CERTIFICATE-----
 
-imageContentSources:
+<image-config>: <1>
 - mirrors:
   - registry.example.com:5000/ocp4/openshift4
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
@@ -70,5 +71,8 @@ imageContentSources:
   source: quay.io/openshift-release-dev/ocp-release
 
 ----
+Where:
++
+<1> `<image-config>` is either `imageContentSources` for OpenShift 4.13 and below, or `imageDigestSources` for Openshift 4.14 and above.
 
 NOTE: Indentation is important in the yml file. Ensure your copy of the `install-config-appends.yml` is properly indented as in the example above.

--- a/documentation/ipi-install/modules/ipi-install-creating-a-disconnected-registry.adoc
+++ b/documentation/ipi-install/modules/ipi-install-creating-a-disconnected-registry.adoc
@@ -218,7 +218,7 @@ $ sed -e 's/^/  /' /opt/registry/certs/domain.crt >> install-config.yaml
 [source,terminal]
 ----
 $ cat <<EOF >> install-config.yaml
-imageContentSources:
+<image-config>: <1>
 - mirrors:
   - registry.example.com:5000/ocp4/openshift4
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
@@ -230,5 +230,8 @@ imageContentSources:
   source: quay.io/openshift-release-dev/ocp-release
 EOF
 ----
+Where:
++
+<1> You must replace `<image-config>` with `imageContentSources` for OpenShift 4.13 and below, or `imageDigestSources` for Openshift 4.14 and above.
 +
 NOTE: Replace `registry.example.com` with the registry's fully qualified domain name.

--- a/documentation/ipi-install/modules/ipi-install-troubleshooting-install-config.adoc
+++ b/documentation/ipi-install/modules/ipi-install-troubleshooting-install-config.adoc
@@ -5,7 +5,7 @@
 
 = Troubleshooting `install-config.yaml`
 
-The `install-config.yaml` configuration file represents all of the nodes that are part of the {product-title} cluster. The file contains the necessary options consisting of but not limited to `apiVersion`, `baseDomain`, `imageContentSources` and virtual IP addresses. If errors occur early in the deployment of the {product-title} cluster, the errors are likely in the `install-config.yaml` configuration file.
+The `install-config.yaml` configuration file represents all of the nodes that are part of the {product-title} cluster. The file contains the necessary options consisting of but not limited to `apiVersion`, `baseDomain`, `imageContentSources` (OpenShift 4.13 and below) or `imageDigestSources` (OpenShirt 4.14 and above), and virtual IP addresses. If errors occur early in the deployment of the {product-title} cluster, the errors are likely in the `install-config.yaml` configuration file.
 
 .Procedure
 


### PR DESCRIPTION
The imageContentSources is being deprecated in the openshift-installer and imageDigestSources is replacing it.
Allow the use of imageDigestSources when the disconnected registry is created. Updating docs to reflect the use of each CR depending on the OCP version

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #964 

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Locally tested generating the template
- Also tested using a custom `disconnected_registry_mirrors_file` in a disconnected cluster in [this DCI job](https://www.distributed-ci.io/jobs/861839b9-76d8-4877-a630-47ba1db05fd4) (see the [install-config.yml](https://www.distributed-ci.io/files/155d83d5-c490-48d7-8eda-7f87235718a5) including the `imageDigestSource`)  must-gather tarball is also included in the job and that shows the `idms` where loaded:

```Shell
❯ omc get idms
NAME                    AGE
image-digest-mirror-0   Unknown
image-digest-mirror-1   Unknown
```

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
