### PR TITLE
Add externalMACAddress in virtualmedia template

### DIFF
--- a/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
@@ -72,8 +72,13 @@ platform:
     externalBridge: {{ baremetal_bridge }}
 {% endif %}
     provisioningNetwork: "Disabled"
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int == 6)) %}
     provisioningHostIP: {{ provisioningHostIP }}
+{% endif %}
     bootstrapProvisioningIP: {{ bootstrapProvisioningIP }}
+{% if externalMACAddress is defined and externalMACAddress|length %}
+    externalMACAddress: '{{ externalMACAddress }}'
+{% endif %}
 {% if bootstraposimage is defined and bootstraposimage|length %}
     bootstrapOSImage: {{ bootstraposimage }}
 {% endif %}

--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -525,6 +525,7 @@
   when:
     - enable_virtualmedia|bool
     - provisioningHostIP is undefined
+    - release_version.split('.')[0]|int == 4 and release_version.split('.')[1]|int == 6
   tags:
     - always
     - validation


### PR DESCRIPTION
# Description

- `externalMACAddress` is lacking in the virtualmedia template, letting libvirt to generate the provisioner hwaddr, this change brings parity with non-virtualmedia installs that uses provisioning network
- Make `provisioningHostIP` required only in 4.6 where virtual media sets `provisioningNetwork: "Disabled"`


Fixes #973 

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Tested in a lab with a disconnected environment.

**Test Configuration**:

- Versions: OCP 4.13
- Hardware: HP 

## Checklist

- [x ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
