### PR TITLE
Added redfish for KVM option to install-config template

### DIFF
--- a/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config-virtualmedia.j2
@@ -76,8 +76,8 @@ platform:
     provisioningHostIP: {{ provisioningHostIP }}
 {% endif %}
     bootstrapProvisioningIP: {{ bootstrapProvisioningIP }}
-{% if externalMACAddress is defined and externalMACAddress|length %}
-    externalMACAddress: '{{ externalMACAddress }}'
+{% if externalMACAddress is defined %}
+    externalMACAddress: {{ externalMACAddress }}
 {% endif %}
 {% if bootstraposimage is defined and bootstraposimage|length %}
     bootstrapOSImage: {{ bootstraposimage }}
@@ -96,6 +96,9 @@ platform:
 {% elif groups['hp_hosts_redfish'] is defined and host in groups['hp_hosts_redfish'] and ((release_version.split('.')[0]|int > 4) or ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 6))) and enable_virtualmedia|bool %}
           address: redfish-virtualmedia://{{ hostvars[host]['ipmi_address']|ipwrap }}/redfish/v1/Systems/1
           disableCertificateVerification: {{ disable_bmc_certificate_verification }}
+{% elif groups['kvm_hosts_redfish'] is defined and host in groups['kvm_hosts_redfish'] %}
+          address: redfish-virtualmedia://{{ hostvars[host]['ipmi_address']|ipwrap }}:{{ hostvars[host]['redfish_port'] }}/redfish/v1/Systems/{{ hostvars[host]['kvm_uuid'] }}
+          disableCertificateVerification: true
 {% elif ansible_system_vendor == 'Dell Inc.' %}
           address: idrac-virtualmedia://{{ hostvars[host]['ipmi_address']|ipwrap }}/redfish/v1/Systems/System.Embedded.1
           disableCertificateVerification: {{ disable_bmc_certificate_verification }}
@@ -140,6 +143,9 @@ platform:
 {% elif groups['hp_hosts_redfish'] is defined and host in groups['hp_hosts_redfish'] and ((release_version.split('.')[0]|int > 4) or ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 6))) and enable_virtualmedia|bool %}
           address: redfish-virtualmedia://{{ hostvars[host]['ipmi_address']|ipwrap }}/redfish/v1/Systems/1
           disableCertificateVerification: {{ disable_bmc_certificate_verification }}
+{% elif groups['kvm_hosts_redfish'] is defined and host in groups['kvm_hosts_redfish'] %}
+          address: redfish-virtualmedia://{{ hostvars[host]['ipmi_address']|ipwrap }}:{{ hostvars[host]['redfish_port'] }}/redfish/v1/Systems/{{ hostvars[host]['kvm_uuid'] }}
+          disableCertificateVerification: true
 {% elif ansible_system_vendor == 'Dell Inc.' %}
           address: idrac-virtualmedia://{{ hostvars[host]['ipmi_address']|ipwrap }}/redfish/v1/Systems/System.Embedded.1
           disableCertificateVerification: {{ disable_bmc_certificate_verification }}

--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -99,6 +99,9 @@ platform:
 {% elif groups['hp_hosts_redfish'] is defined and host in groups['hp_hosts_redfish'] and ((release_version.split('.')[0]|int > 4) or ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 5))) %}
           address: redfish://{{ hostvars[host]['ipmi_address']|ipwrap }}/redfish/v1/Systems/1
           disableCertificateVerification: {{ disable_bmc_certificate_verification }}
+{% elif groups['kvm_hosts_redfish'] is defined and host in groups['kvm_hosts_redfish'] %}
+          address: redfish://{{ hostvars[host]['ipmi_address']|ipwrap }}:{{ hostvars[host]['redfish_port'] }}/redfish/v1/Systems/{{ hostvars[host]['kvm_uuid'] }}
+          disableCertificateVerification: true
 {% elif hostvars[host]['irmc_address'] is defined %}
           address: irmc://{{ hostvars[host]['irmc_address']|ipwrap }}:{{ hostvars[host]['irmc_port']|default(443) }}
 {% else %}
@@ -141,6 +144,9 @@ platform:
 {% elif groups['hp_hosts_redfish'] is defined and host in groups['hp_hosts_redfish'] %}
           address: redfish://{{ hostvars[host]['ipmi_address']|ipwrap }}/redfish/v1/Systems/1
           disableCertificateVerification: {{ disable_bmc_certificate_verification }}
+{% elif groups['kvm_hosts_redfish'] is defined and host in groups['kvm_hosts_redfish'] %}
+          address: redfish://{{ hostvars[host]['ipmi_address']|ipwrap }}:{{ hostvars[host]['redfish_port'] }}/redfish/v1/Systems/{{ hostvars[host]['kvm_uuid'] }}
+          disableCertificateVerification: true
 {% elif hostvars[host]['irmc_address'] is defined %}
           address: irmc://{{ hostvars[host]['irmc_address']|ipwrap }}:{{ hostvars[host]['irmc_port']|default(443) }}
 {% else %}

--- a/documentation/ipi-install/ipi-install-configuration-files.adoc
+++ b/documentation/ipi-install/ipi-install-configuration-files.adoc
@@ -30,6 +30,8 @@ ifeval::[{product-version} > 4.7]
 include::modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc[leveloffset=+2]
 endif::[]
 
+include::modules/ipi-install-bmc-addressing-for-kvm-with-sushy-tools.adoc[leveloffset=+2]
+
 include::modules/ipi-install-root-device-hints.adoc[leveloffset=+1]
 
 include::modules/ipi-install-creating-the-openshift-manifests.adoc[leveloffset=+1]

--- a/documentation/ipi-install/modules/ipi-install-bmc-addressing-for-kvm-with-sushy-tools.adoc
+++ b/documentation/ipi-install/modules/ipi-install-bmc-addressing-for-kvm-with-sushy-tools.adoc
@@ -1,0 +1,118 @@
+// This is included in the following assemblies:
+//
+// installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
+
+[id='bmc-addressing-for-hpe-ilo_{context}']
+= BMC addressing for KVM with sushy-tools Redfish emulator
+
+The `address` field for each `bmc` entry is a URL for connecting to the {product-title} cluster nodes, including the type of controller in the URL scheme and its location on the network.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    hosts:
+      - name: <host name>
+        role: <master | worker>
+        bmc:
+          address: <address> <1>
+          username: <user>
+          password: <password>
+----
+<1> The `address` configuration setting specifies the protocol.
+
+For KVM working with sushy-tools Redfish emulator, Red Hat supports Redfish virtual media and Redfish network boot.
+
+.BMC address formats for KVM with sushy-tools Redfish emulator
+[frame="topbot",options="header"]
+|====
+|Protocol|Address Format
+|Redfish virtual media| `redfish-virtualmedia://<out-of-band-ip>:<sushy-tools-port>/redfish/v1/Systems/<system-id>`
+|Redfish network boot| `redfish://<out-of-band-ip>:<sushy-tools-port>/redfish/v1/Systems/<system-id>`
+|====
+
+[NOTE]
+====
+The sushy-tools Redfish emulator runs from the KVM hypervisor and a single instance acts as the virtual BMC for all the guest machines. This means both the out of band IP address and port, will be same and each individual machine must be identified by its System ID.
+
+You may retrieve the System ID of your guest machines with the following command:
+
+[source,bash]
+---
+$ virsh list --all --name --uuid
+d8ac6bf8-3062-4954-84c3-e097faa17025 compute-0
+84971a71-3935-4a92-8d90-a9f8440dac09 compute-1
+92430f42-8805-4412-959a-2a7252c7c540 compute-2
+0fea5296-db95-41d7-9295-f57cfa50255f control-plane-0
+4986e405-fd3a-483d-9210-8cb120b98f80 control-plane-1
+26bf228c-44fd-4c49-9e6f-44f4b5968b34 control-plane-2
+---
+====
+
+See the following sections for additional details.
+
+.Redfish virtual media for KVM with sushy-tools Redfish emulator
+
+To enable Redfish virtual media for KVM environments running the sushy-tools Redfish emulator, use `redfish-virtualmedia://` in the `address` setting. The following example demonstrates using Redfish virtual media within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish-virtualmedia://<out-of-band-ip>:<sushy-tools-port>/redfish/v1/Systems/<system-id>
+          username: <user>
+          password: <password>
+----
+
+While it is recommended to have a certificate of authority for the out-of-band management addresses, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. The following example demonstrates a Redfish configuration using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish-virtualmedia://<out-of-band-ip>:<sushy-tools-port>/redfish/v1/Systems/<system-id>
+          username: <user>
+          password: <password>
+          disableCertificateVerification: True
+----
+
+.Redfish network boot for KVM with sushy-tools Redfish emulator
+
+To enable Redfish, use `redfish://` or `redfish+http://` to disable TLS. The installer requires the host name or the IP address, the Redfish emulator listening port and the path to the system ID. The following example demonstrates a Redfish configuration within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish://<out-of-band-ip>:<sushy-tools-port>/redfish/v1/Systems/<system-id>
+          username: <user>
+          password: <password>
+----
+
+While it is recommended to have a certificate of authority for the out-of-band management addresses, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. The following example demonstrates a Redfish configuration using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish://<out-of-band-ip>:<sushy-tools-port>/redfish/v1/Systems/<system-id>
+          username: <user>
+          password: <password>
+          disableCertificateVerification: True
+----


### PR DESCRIPTION
# Description

Currently redfish is supported for HP and Dell systems, but none of
these vendors provide settings compatible with sushy-tools based virtual
BMCs. For instance, all the KVMs in the same hypervisor share the BMC
address, and are differentiated by the system ID, which is part of the
resource path.
    
This change extends the install-config and install-config-virtualmedia
templates to allow for sushy-tools based redfish vBMCs.

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Ran a [DCI job](https://www.distributed-ci.io/jobs/e6f98425-8d0c-4cf3-8474-3e1ea1a1802c/jobStates?sort=date) exercising this use case.

**Test Configuration**:

- Versions: OCP-4.13.13
- Hardware: KVM

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [x] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [x] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
