### PR TITLE
Change the RHCOS image cache container public registry

### DIFF
--- a/ansible-ipi-install/roles/installer/defaults/main.yml
+++ b/ansible-ipi-install/roles/installer/defaults/main.yml
@@ -9,6 +9,7 @@ install_config_appends_file: install-config-appends.yml
 registry_auth_file: registry-auths.json
 disconnected_registry_user: dummy
 disconnected_registry_password: dummy
+webserver_cache_image: "quay.io/centos7/httpd-24-centos7:latest"
 webserver_caching_port: "{{ webserver_caching_port_container }}"
 webserver_caching_port_container: 8080
 registry_creation: false

--- a/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
+++ b/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
@@ -170,7 +170,7 @@
 - name: Start RHCOS image cache container
   containers.podman.podman_container:
     name: rhcos_image_cache
-    image: registry.centos.org/centos/httpd-24-centos7:latest
+    image: "{{ webserver_cache_image }}"
     state: stopped
     network: host
     volumes:


### PR DESCRIPTION
# Description

registry.centos.org seems to be done or unavailable. Changing from registry.centos.org to quay.io and add the ability to change it if needed.

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Checklist

- [X] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
