### PR TITLE
install-config.j2: support disableCertificateVerification for irmc

### DIFF
--- a/ansible-ipi-install/roles/installer/templates/install-config.j2
+++ b/ansible-ipi-install/roles/installer/templates/install-config.j2
@@ -101,6 +101,7 @@ platform:
           disableCertificateVerification: {{ disable_bmc_certificate_verification }}
 {% elif hostvars[host]['irmc_address'] is defined %}
           address: irmc://{{ hostvars[host]['irmc_address']|ipwrap }}:{{ hostvars[host]['irmc_port']|default(443) }}
+          disableCertificateVerification: {{ disable_bmc_certificate_verification }}
 {% else %}
           address: ipmi://{{ hostvars[host]['ipmi_address']|ipwrap }}:{{ hostvars[host]['ipmi_port']|default(623) }}
 {% endif %}
@@ -143,6 +144,7 @@ platform:
           disableCertificateVerification: {{ disable_bmc_certificate_verification }}
 {% elif hostvars[host]['irmc_address'] is defined %}
           address: irmc://{{ hostvars[host]['irmc_address']|ipwrap }}:{{ hostvars[host]['irmc_port']|default(443) }}
+          disableCertificateVerification: {{ disable_bmc_certificate_verification }}
 {% else %}
           address: ipmi://{{ hostvars[host]['ipmi_address']|ipwrap }}:{{ hostvars[host]['ipmi_port']|default(623) }}
 {% endif %}


### PR DESCRIPTION
Change the template to add disableCertificateVerification field for irmc when generating install-config.

