### PR TITLE
Allowing status code 301 when verifying the internet connectivity

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/20_extract_installer.yml
+++ b/ansible-ipi-install/roles/installer/tasks/20_extract_installer.yml
@@ -65,7 +65,7 @@
 - name: Confirm whether or not internet connectivity on provisioner host
   uri:
     url: https://www.redhat.com
-    status_code: [-1, 200]
+    status_code: [-1, 200, 301]
     timeout: 1
   register: the_url
   tags:
@@ -86,7 +86,7 @@
     --to {{ tempdir_loc }} {{ disconnected_installer | ternary(disconnected_installer, release_image) }}
   args:
     chdir: "{{ tempdir }}"
-  when: (disconnected_installer|length or the_url.status == 200)
+  when: (disconnected_installer|length or the_url.status in [200,301])
   delegate_to: "{{ disconnected_installer | ternary(groups['registry_host'][0], groups['provisioner'][0]) }}"
   tags: extract
 

--- a/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
+++ b/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
@@ -6,7 +6,7 @@
 - name: Confirm whether or not internet connectivity on provisioner host
   uri:
     url: https://www.redhat.com
-    status_code: [-1, 200]
+    status_code: [-1, 200, 301]
     timeout: 1
   register: the_url
   tags: cache
@@ -15,7 +15,7 @@
   set_fact:
     url_passed: true
   when:
-    - the_url.status == 200
+    - the_url.status in [200,301]
   tags: cache
 
 - name: Get URL of host providing the webserver
@@ -136,7 +136,7 @@
   # use a ternary for the delegate_to
 - name: Get URL of host providing the webserver
   set_fact:
-    host_url: "{{ the_url.status == 200 | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
+    host_url: "{{ the_url.status in [200,301] | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
   tags: cache
 
 - name: Set bootstrap image URL override if not provided by the user

--- a/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
+++ b/ansible-ipi-install/roles/node-prep/tasks/10_validation.yml
@@ -212,7 +212,7 @@
 - name: Confirm whether or not internet connectivity on provisioner host
   uri:
     url: https://www.redhat.com
-    status_code: [-1, 200]
+    status_code: [-1, 200, 301]
     timeout: 1
   register: check_url
   tags:


### PR DESCRIPTION
Currently, when checking the connectivity to the Internet, an HTTP query is set against https://www.redhat.com.

This address will respond with a 301 status code redirecting the client to https://www.redhat.com/en.

The URI ansible module is able to follow redirects so, if everything is OK, the query shour result in either a 200 status code if the server is reachable, or a -1 if it's not. In this later scenario, a disconnected environment is assumed.

The problem is in some labs the web server gets into an infinite redirect loop, so the resulting status code would be 301.

This change allows for this status code to be accepted as evidence that the Red Hat web site was reached and, therefore, the network has Internet access.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please select the appropriate options:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Versions:
- Hardware:

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
