### PR TITLE
Fix task Get URL of host providing the webserver

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
+++ b/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml
@@ -136,7 +136,7 @@
   # use a ternary for the delegate_to
 - name: Get URL of host providing the webserver
   set_fact:
-    host_url: "{{ the_url.status in [200,301] | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
+    host_url: "{{ (the_url.status in [200,301]) | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
   tags: cache
 
 - name: Set bootstrap image URL override if not provided by the user


### PR DESCRIPTION
# Description

In the process of redeploying one cluster, we ran into the following issue:

Fixes # 

```
TASK [installer : Get URL of host providing the webserver] *********************

task path: /var/lib/dci-openshift-agent/baremetal_deploy_repo/ansible-ipi-install/roles/installer/tasks/24_rhcos_image_cache.yml:137

fatal: [[XXX](XXX]: FAILED! => {"msg": "Unexpected templating type error occurred on ({{ the_url.status in [200,301] | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}): 'in <string>' requires string as left operand, not int"}
```

## Type of change

Please select the appropriate options:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

I tested this PR in the same cluster that is failing and everything is working fine.

**Test Configuration**:

- Versions: OCP 4.13
- Hardware: HPE servers

## Checklist

- [X] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [X] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [X] PRs should not be merged unless positively reviewed.
