### PR TITLE
Change RHCOS URL path for pre 4.8 installs

### DIFF
--- a/ansible-ipi-install/roles/installer/tasks/23_rhcos_image_paths.yml
+++ b/ansible-ipi-install/roles/installer/tasks/23_rhcos_image_paths.yml
@@ -23,11 +23,16 @@
       delegate_to: "{{ disconnected_installer | ternary(groups['registry_host'][0], groups['provisioner'][0]) }}"
       tags: rhcospath
 
+    # The baseURI for pre 4.8 is decomissioned, but old images are still available along newer ones
+    # only when cache_enabled is set to True
     - name: Set Facts for RHCOS_URI and RHCOS_PATH
+      vars:
+        base_version: "{{ release_version.split('.')[:2] | join('.') }}"
+        build_id: "{{ rhcos_json.json | json_query('buildid') }}"
       set_fact:
         rhcos_qemu_uri: "{{ rhcos_json.json | json_query('images.qemu.path') }}"
         rhcos_uri: "{{ rhcos_json.json | json_query('images.openstack.path') }}"
-        rhcos_path: "{{ rhcos_json.json | json_query('baseURI') }}"
+        rhcos_path: "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-{{ base_version }}/{{ build_id }}/x86_64/"
       tags: rhcospath
   when: (release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int <= 7)
 


### PR DESCRIPTION
The baseURI used in older (EOL) versions of OCP has been decomissioned some time ago. This change uses the same base URL than the newer RHCOS images currently supported where older images are still available.

This change only helps those cases where  `cache_enabled`.

This is cherry-picked from https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/71

## Type of change

Please select the appropriate options:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

## Testing

https://www.distributed-ci.io/jobs/056a9340-ffaf-48f4-8407-4e6c130bf523/jobStates

- Versions: 4.7.55
- Hardware: libvirt in a connected environment

## Checklist

- [x] I have performed a self-review of my own code
- [ ] If a change is adding a feature, it should require a change to the README.md and the review should catch this.
- [ ] If the change is a fix, it should have an issue. The review should make sure the comments state the issue (not just the number) and it should use the keywords that will close the issue on merge.
- [ ] A change should not be merged unless it passes CI or there is a comment/update saying what testing was passed.
- [ ] PRs should not be merged unless positively reviewed.
